### PR TITLE
Fix many transfer issues and recover from common problems

### DIFF
--- a/cax/main.py
+++ b/cax/main.py
@@ -44,7 +44,8 @@ def main():
              checksum.AddChecksum(),
              checksum.CompareChecksums(),
              clear.ClearDAQBuffer(),
-             clear.AlertFailedTransfer(),
+             clear.RetryStalledTransfer(),
+             clear.RetryBadChecksumTransfer(),
              ]
 
     while True:

--- a/cax/main.py
+++ b/cax/main.py
@@ -39,8 +39,8 @@ def main():
     logging.getLogger('').addHandler(console)
 
     tasks = [process.ProcessBatchQueue(),
-             #data_mover.SCPPush(),
-             #data_mover.SCPPull(),
+             data_mover.SCPPush(),
+             data_mover.SCPPull(),
              checksum.AddChecksum(),
              checksum.CompareChecksums(),
              clear.ClearDAQBuffer(),

--- a/cax/main.py
+++ b/cax/main.py
@@ -39,8 +39,8 @@ def main():
     logging.getLogger('').addHandler(console)
 
     tasks = [process.ProcessBatchQueue(),
-             data_mover.SCPPush(),
-             data_mover.SCPPull(),
+             #data_mover.SCPPush(),
+             #data_mover.SCPPull(),
              checksum.AddChecksum(),
              checksum.CompareChecksums(),
              clear.ClearDAQBuffer(),

--- a/cax/task.py
+++ b/cax/task.py
@@ -17,7 +17,8 @@ class Task():
 
         # Collect all run documents.  This has to be turned into a list
         # to avoid timeouts if a task takes too long.
-        docs = list(self.collection.find({'detector': 'tpc'}))
+        docs = list(self.collection.find({'detector': 'tpc',
+                                          'number' : 51}))
 
         for doc in docs:
             # Make sure up to date

--- a/cax/task.py
+++ b/cax/task.py
@@ -19,7 +19,10 @@ class Task():
         # to avoid timeouts if a task takes too long.
         docs = list(self.collection.find({'detector': 'tpc'}))
 
-        for self.run_doc in docs:
+        for doc in docs:
+            # Make sure up to date
+            self.run_doc = self.collection.find_one({'_id' : doc['_id']})
+
             if 'data' not in self.run_doc:
                 continue
 

--- a/cax/task.py
+++ b/cax/task.py
@@ -18,7 +18,7 @@ class Task():
         # Collect all run documents.  This has to be turned into a list
         # to avoid timeouts if a task takes too long.
         docs = list(self.collection.find({'detector': 'tpc',
-                                          'number' : 51}))
+                                          'number' : {"$gt": 500}}))
 
         for doc in docs:
             # Make sure up to date

--- a/cax/task.py
+++ b/cax/task.py
@@ -15,7 +15,11 @@ class Task():
     def go(self):
         """Run this periodically"""
 
-        for self.run_doc in self.collection.find({'detector': 'tpc'}):
+        # Collect all run documents.  This has to be turned into a list
+        # to avoid timeouts if a task takes too long.
+        docs = list(self.collection.find({'detector': 'tpc'}))
+
+        for self.run_doc in docs:
             if 'data' not in self.run_doc:
                 continue
 

--- a/cax/tasks/checksum.py
+++ b/cax/tasks/checksum.py
@@ -91,8 +91,8 @@ class CompareChecksums(Task):
 
     def each_run(self):
         self.log.info("Checking raw checksums")
-        self.check('raw')
+        self.log.info(self.check('raw'))
 
         self.log.info("Checking processed checksums")
-        self.check('processed')
+        self.log.info(self.check('processed'))
 

--- a/cax/tasks/checksum.py
+++ b/cax/tasks/checksum.py
@@ -90,11 +90,11 @@ class CompareChecksums(Task):
         return n
 
     def each_run(self):
-        self.log.info("Checking raw checksums "
+        self.log.debug("Checking raw checksums "
                       "run %d" % self.run_doc['number'])
-        self.log.info(self.check('raw'))
+        self.check('raw')
 
-        self.log.info("Checking processed checksums "
+        self.log.debug("Checking processed checksums "
                       "run %d" % self.run_doc['number'])
-        self.log.info(self.check('processed'))
+        self.check('processed')
 

--- a/cax/tasks/checksum.py
+++ b/cax/tasks/checksum.py
@@ -34,8 +34,8 @@ class AddChecksum(Task):
                       "%d %s" % (self.run_doc['number'],
                                  data_doc['type']))
         self.collection.update({'_id': self.run_doc['_id'],
-                                'data.host': data_doc['host'],
-                                'data.type': data_doc['type']},
+                                'data': {'$elemMatch': { 'host': data_doc['host'],
+                                                         'type': data_doc['type']}}},
                                {'$set': {'data.$': data_doc}})
 
 

--- a/cax/tasks/checksum.py
+++ b/cax/tasks/checksum.py
@@ -90,9 +90,11 @@ class CompareChecksums(Task):
         return n
 
     def each_run(self):
-        self.log.info("Checking raw checksums")
+        self.log.info("Checking raw checksums "
+                      "run %d" % self.run_doc['number'])
         self.log.info(self.check('raw'))
 
-        self.log.info("Checking processed checksums")
+        self.log.info("Checking processed checksums "
+                      "run %d" % self.run_doc['number'])
         self.log.info(self.check('processed'))
 

--- a/cax/tasks/checksum.py
+++ b/cax/tasks/checksum.py
@@ -34,7 +34,8 @@ class AddChecksum(Task):
                       "%d %s" % (self.run_doc['number'],
                                  data_doc['type']))
         self.collection.update({'_id': self.run_doc['_id'],
-                                'data.host': data_doc['host']},
+                                'data.host': data_doc['host'],
+                                'data.type': data_doc['type']},
                                {'$set': {'data.$': data_doc}})
 
 

--- a/cax/tasks/checksum.py
+++ b/cax/tasks/checksum.py
@@ -58,8 +58,7 @@ class CompareChecksums(Task):
     def check(self,
               data_type='raw',
               warn=True):
-        fail = False
-
+        """Returns number of good locations"""
         n = 0
 
         master = self.get_main_checksum(data_type)
@@ -81,12 +80,9 @@ class CompareChecksums(Task):
                     error = "Local checksum error " \
                             "run %d" % self.run_doc['number']
                     if warn: self.give_error(error)
-                    fail = True
             else:
                 n += 1
 
-        if fail:
-            return 0
         return n
 
     def each_run(self):

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -68,8 +68,8 @@ class AlertFailedTransfer(checksum.CompareChecksums):
 
         if difference > datetime.timedelta(days=1):  # If stale transfer
             self.give_error("Transfer run %d (%s) lasting more than "
-                            "one day" % self.run_doc['number'],
-                                        self.run_doc['name'])
+                            "one day" % (self.run_doc['number'],
+                                        self.run_doc['name']))
 
         # if difference > datetime.timedelta(days=2):  # If stale transfer
         #     self.give_error("Transfer lasting more than one week, retry.")

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -45,6 +45,7 @@ class ClearDAQBuffer(checksum.CompareChecksums):
 class AlertFailedTransfer(checksum.CompareChecksums):
     """Alert if stale transfer."""
 
+    # Do not overload this routine.
     each_run = task.Tasks.each_run
 
     def each_location(self, data_doc):
@@ -67,16 +68,16 @@ class AlertFailedTransfer(checksum.CompareChecksums):
         if difference > datetime.timedelta(days=1):  # If stale transfer
             self.give_error("Transfer lasting more than one day")
 
-        if difference > datetime.timedelta(days=2):  # If stale transfer
-            self.give_error("Transfer lasting more than one week, retry.")
-
-            values = self.get_checksums()
-            if self.count(values) > 2:
-                self.log.info("Deleting %s" % data_doc['location'])
-                shutil.rmtree(data_doc['location'])
-                self.log.error('Deleted, notify run database.')
-
-                resp = self.collection.update({'_id': self.run_doc['_id']},
-                                              {'$pull': {'data' : data_doc}})
-                self.log.error('Removed from run database.')
-                self.log.debug(resp)
+        # if difference > datetime.timedelta(days=2):  # If stale transfer
+        #     self.give_error("Transfer lasting more than one week, retry.")
+        #
+        #     values = self.get_checksums()
+        #     if self.count(values) > 2:
+        #         self.log.info("Deleting %s" % data_doc['location'])
+        #         shutil.rmtree(data_doc['location'])
+        #         self.log.error('Deleted, notify run database.')
+        #
+        #         resp = self.collection.update({'_id': self.run_doc['_id']},
+        #                                       {'$pull': {'data' : data_doc}})
+        #         self.log.error('Removed from run database.')
+        #         self.log.debug(resp)

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -73,7 +73,7 @@ class AlertFailedTransfer(checksum.CompareChecksums):
 
         if difference > datetime.timedelta(days=2):  # If stale transfer
             self.give_error("Transfer lasting more than two days, retry.")
-            if self.check(warn=False) > 2:
+            if self.check(warn=False) > 0:
                 self.log.info("Deleting %s" % data_doc['location'])
                 shutil.rmtree(data_doc['location'])
                 self.log.error('Deleted, notify run database.')

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -73,7 +73,7 @@ class RetryStalledTransfer(checksum.CompareChecksums):
 
         if difference > datetime.timedelta(days=2):  # If stale transfer
             self.give_error("Transfer lasting more than two days, retry.")
-            if self.check(warn=False) > 0:
+            if self.check(warn=False) > 1:
                 self.log.info("Deleting %s" % data_doc['location'])
 
                 if os.path.isdir(data_doc['location']):
@@ -105,7 +105,7 @@ class RetryBadChecksumTransfer(checksum.CompareChecksums):
 
         if self.get_main_checksum(data_doc['type']) != data_doc['checksum']:
             self.give_error("Bad checksum")
-            if self.check(warn=False) > 0:
+            if self.check(warn=False) > 1:
                 self.log.info("Deleting %s" % data_doc['location'])
 
                 if os.path.isdir(data_doc['location']):

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -5,7 +5,8 @@ import shutil
 import pymongo
 
 from cax.tasks import checksum
-from cax import config, task
+from cax import config
+from cax.task import Task
 
 
 class ClearDAQBuffer(checksum.CompareChecksums):
@@ -46,7 +47,7 @@ class AlertFailedTransfer(checksum.CompareChecksums):
     """Alert if stale transfer."""
 
     # Do not overload this routine.
-    each_run = task.Tasks.each_run
+    each_run = Task.each_run
 
     def each_location(self, data_doc):
         if 'host' not in data_doc or data_doc['host'] != config.get_hostname():

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -65,7 +65,7 @@ class AlertFailedTransfer(checksum.CompareChecksums):
 
         self.log.debug(difference)
 
-        if difference > datetime.timedelta(minute=1):  # If stale transfer
+        if difference > datetime.timedelta(day=1):  # If stale transfer
             self.give_error("Transfer %s from run %d (%s) lasting more than "
                             "one day" % (data_doc['type'],
                                          self.run_doc['number'],

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -67,7 +67,9 @@ class AlertFailedTransfer(checksum.CompareChecksums):
         self.log.debug(difference)
 
         if difference > datetime.timedelta(days=1):  # If stale transfer
-            self.give_error("Transfer lasting more than one day")
+            self.give_error("Transfer run %d (%s) lasting more than "
+                            "one day" % self.run_doc['number'],
+                                        self.run_doc['name'])
 
         # if difference > datetime.timedelta(days=2):  # If stale transfer
         #     self.give_error("Transfer lasting more than one week, retry.")

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -48,6 +48,12 @@ class RetryStalledTransfer(checksum.CompareChecksums):
     # Do not overload this routine.
     each_run = Task.each_run
 
+    def has_untriggered(self):
+        for data_doc in self.run_doc['data']:
+            if data_doc['type'] == 'untriggered':
+                return True
+        return False
+
     def each_location(self, data_doc):
         if 'host' not in data_doc or data_doc['host'] != config.get_hostname():
             return # Skip places where we can't locally access data
@@ -73,7 +79,7 @@ class RetryStalledTransfer(checksum.CompareChecksums):
 
         if difference > datetime.timedelta(days=2):  # If stale transfer
             self.give_error("Transfer lasting more than two days, retry.")
-            if self.check(warn=False) > 1:
+            if self.check(warn=False) > 1 or self.has_untriggered():
                 self.log.info("Deleting %s" % data_doc['location'])
 
                 if os.path.isdir(data_doc['location']):

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -67,9 +67,10 @@ class AlertFailedTransfer(checksum.CompareChecksums):
         self.log.debug(difference)
 
         if difference > datetime.timedelta(days=1):  # If stale transfer
-            self.give_error("Transfer run %d (%s) lasting more than "
-                            "one day" % (self.run_doc['number'],
-                                        self.run_doc['name']))
+            self.give_error("Transfer %s from run %d (%s) lasting more than "
+                            "one day" % (data_doc['type'],
+                                         self.run_doc['number'],
+                                         self.run_doc['name']))
 
         # if difference > datetime.timedelta(days=2):  # If stale transfer
         #     self.give_error("Transfer lasting more than one week, retry.")

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -65,7 +65,7 @@ class RetryStalledTransfer(checksum.CompareChecksums):
 
         self.log.debug(difference)
 
-        if difference > datetime.timedelta(day=1):  # If stale transfer
+        if difference > datetime.timedelta(days=1):  # If stale transfer
             self.give_error("Transfer %s from run %d (%s) lasting more than "
                             "one day" % (data_doc['type'],
                                          self.run_doc['number'],

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -4,8 +4,8 @@ import shutil
 
 import pymongo
 
-from . import checksum
-from cax import config
+from cax.tasks import checksum
+from cax import config, task
 
 
 class ClearDAQBuffer(checksum.CompareChecksums):
@@ -44,6 +44,8 @@ class ClearDAQBuffer(checksum.CompareChecksums):
 
 class AlertFailedTransfer(checksum.CompareChecksums):
     """Alert if stale transfer."""
+
+    each_run = task.Tasks.each_run
 
     def each_location(self, data_doc):
         if 'host' not in data_doc or data_doc['host'] != config.get_hostname():

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -65,7 +65,7 @@ class AlertFailedTransfer(checksum.CompareChecksums):
 
         self.log.debug(difference)
 
-        if difference > datetime.timedelta(days=1):  # If stale transfer
+        if difference > datetime.timedelta(minute=1):  # If stale transfer
             self.give_error("Transfer %s from run %d (%s) lasting more than "
                             "one day" % (data_doc['type'],
                                          self.run_doc['number'],

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -75,8 +75,14 @@ class AlertFailedTransfer(checksum.CompareChecksums):
             self.give_error("Transfer lasting more than two days, retry.")
             if self.check(warn=False) > 0:
                 self.log.info("Deleting %s" % data_doc['location'])
-                shutil.rmtree(data_doc['location'])
-                self.log.error('Deleted, notify run database.')
+
+                if os.path.isdir(data_doc['location']):
+                    shutil.rmtree(data_doc['location'])
+                    self.log.error('Deleted, notify run database.')
+                elif os.path.isfile(data_doc['location']):
+                    os.remove(data_doc['location'])
+                else:
+                    self.log.error('did not exist, notify run database.')
 
                 resp = self.collection.update({'_id': self.run_doc['_id']},
                                                {'$pull': {'data' : data_doc}})

--- a/cax/tasks/data_mover.py
+++ b/cax/tasks/data_mover.py
@@ -57,6 +57,12 @@ class SCPBase(Task):
     """Copy data via SCP base class
     """
 
+    def each_run(self):
+        for data_type in ['raw', 'processed']:
+            self.log.debug("Push %s" % data_type)
+            self.do_possible_transfers(option_type=self.option_type,
+                                       data_type=data_type)
+
     def do_possible_transfers(self, option_type='upload'):
         """Determine candidate transfers
         """
@@ -142,16 +148,11 @@ class SCPPush(SCPBase):
 
     If the data is transfered to current host and does not exist at any other
     site (including transferring), then copy data there."""
-
-    def each_run(self):
-        self.do_possible_transfers(option_type='upload')
-
+    option_type = 'upload'
 
 class SCPPull(SCPBase):
     """Copy data via SCP to here
 
     If data exists at a reachable host but not here, pull it.
     """
-
-    def each_run(self):
-        self.do_possible_transfers(option_type='download')
+    option_type = 'download'

--- a/cax/tasks/data_mover.py
+++ b/cax/tasks/data_mover.py
@@ -146,7 +146,7 @@ class SCPBase(Task):
 
         self.collection.update({'_id': self.run_doc['_id'],
                                 'data.host': datum_new['host'],
-                                'data.type': datum['type']},
+                                'data.type': datum_new['type']},
                                {'$set': {'data.$': datum_new}})
         self.log.info("Transfer complete")
 

--- a/cax/tasks/data_mover.py
+++ b/cax/tasks/data_mover.py
@@ -32,7 +32,8 @@ def copy(datum_original, datum_destination):
 
     logging.info("connection to %s" % server)
     ssh.connect(server,
-                username=username)
+                username=username,
+                compress=True)
 
     # SCPCLient takes a paramiko transport as its only argument
     client = scp.SCPClient(ssh.get_transport())

--- a/cax/tasks/data_mover.py
+++ b/cax/tasks/data_mover.py
@@ -60,7 +60,7 @@ class SCPBase(Task):
 
     def each_run(self):
         for data_type in ['raw', 'processed']:
-            self.log.debug("Push %s" % data_type)
+            self.log.debug("%s" % data_type)
             self.do_possible_transfers(option_type=self.option_type,
                                        data_type=data_type)
 
@@ -145,7 +145,8 @@ class SCPBase(Task):
         self.log.debug("SCP done, telling run database")
 
         self.collection.update({'_id': self.run_doc['_id'],
-                                'data.host': datum_new['host']},
+                                'data.host': datum_new['host'],
+                                'data.type': datum['type']},
                                {'$set': {'data.$': datum_new}})
         self.log.info("Transfer complete")
 

--- a/cax/tasks/data_mover.py
+++ b/cax/tasks/data_mover.py
@@ -63,7 +63,9 @@ class SCPBase(Task):
             self.do_possible_transfers(option_type=self.option_type,
                                        data_type=data_type)
 
-    def do_possible_transfers(self, option_type='upload'):
+    def do_possible_transfers(self,
+                              option_type='upload',
+                              data_type='raw'):
         """Determine candidate transfers
         """
 
@@ -84,7 +86,7 @@ class SCPBase(Task):
             # Iterate over data locations to know status
             for datum in self.run_doc['data']:
                 # Is host known?
-                if 'host' not in datum:
+                if 'host' not in datum or datum['type'] != data_type:
                     continue
 
                 transferred = (datum['status'] == 'transferred')

--- a/cax/tasks/data_mover.py
+++ b/cax/tasks/data_mover.py
@@ -145,8 +145,8 @@ class SCPBase(Task):
         self.log.debug("SCP done, telling run database")
 
         self.collection.update({'_id': self.run_doc['_id'],
-                                'data.host': datum_new['host'],
-                                'data.type': datum_new['type']},
+                                'data': {'$elemMatch': { 'host': datum_new['host'],
+                                                         'type': datum_new['type']}}},
                                {'$set': {'data.$': datum_new}})
         self.log.info("Transfer complete")
 

--- a/cax/tasks/data_mover.py
+++ b/cax/tasks/data_mover.py
@@ -127,6 +127,10 @@ class SCPBase(Task):
                                               ('.root' if datum['type'] == 'processed' else '')),
                      'checksum': None,
                      'creation_time': datetime.datetime.utcnow()}
+
+        if datum['type'] == 'processed':
+            datum_new['pax_version'] = datum['pax_version']
+
         self.collection.update({'_id': self.run_doc['_id']},
                                {'$push': {'data': datum_new}})
         self.log.info('Starting SCP')

--- a/cax/tasks/process.py
+++ b/cax/tasks/process.py
@@ -175,7 +175,7 @@ mv ${{PROCESSING_DIR}}/logs/{name}_*.log ${{OUTPUT_DIR}}/.
                         self.submit(have_raw['location'], have_raw['host'], ncpus)
 
                     else:
-                        self.log.info("Skipping %s with 0 events", self.run_doc['name'])
+                        self.log.debug("Skipping %s with 0 events", self.run_doc['name'])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request fixes many issues we've been having with data transfers.

1.  There was a bug from introducing automatic data processing.  We would only copy either raw or processed data, but not both.
2.  Data transfers will timeout.  After 1 day, we get warning.  After 2, it deletes failed copy if partially transferred.  It also updates the rundb so it should retransfer.  It only deletes if there are enough copies around.
3. Similarly for checksum failures.  If enough good copies and local copy has checksum failure, it will delete local copy and retransfer.
4. Checksums for processed data (this wasn't implemented).
5. Compression in transfers (2-3x increase in speed)
6. Fix timeout with MongoDB where MongoDB times out if not contact in while, which happens if we are SCPing large datasets in between.
7. Kill EB copy if data if untriggered still exists.  This will force retrigger.  (Cannot delete untriggered if DAQ crashes because don't have creationtime from this data location @coderdj )
8. Processed data that was being copied now includes pax_version (only initial processing site had this before)
