### PR TITLE
Midway srm

### DIFF
--- a/cax/cax.json
+++ b/cax/cax.json
@@ -12,7 +12,7 @@
   },
   {
     "name": "midway",
-    "method": [["lcg-cp"], "scp"],
+    "method": ["lcg-cp", "scp"],
     "hostname": "midway-login1.rcc.uchicago.edu",
     "srmname": "srm://srm1.rcc.uchicago.edu:8443/srm/v2/server?SFN=",
     "dir_raw": "/project/lgrandi/xenon1t/raw",

--- a/cax/cax.json
+++ b/cax/cax.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "lena",
-    "method": "scp",
+    "method": ["scp"],
     "hostname": "login.nikhef.nl",
     "dir_raw": "/data/xenon/xenon1t/raw",
     "dir_processed": "/data/xenon/xenon1t/processed",
@@ -11,45 +11,45 @@
     "pax_processing_versions": null
   },
   {
-    "name": "midway-login1",
-    "method": "scp",
+    "name": "midway",
+    "method": [["lcg-cp"], "scp"],
     "hostname": "midway-login1.rcc.uchicago.edu",
+    "srmname": "srm://srm1.rcc.uchicago.edu:8443/srm/v2/server?SFN=",
     "dir_raw": "/project/lgrandi/xenon1t/raw",
     "dir_processed": "/project/lgrandi/xenon1t/processed",
     "upload_options": [],
     "username": "tunnell",
-    "download_options": ["xe1t-datamanager"],
-    "pax_processing_versions": ["v5.0.0"]
+    "download_options": [],
+    "pax_processing_versions": ["v5.2.1"]
   },
   {
     "name": "login",
-    "method": "scp",
+    "method": ["lcg-cp", "scp"],
     "hostname": "login.ci-connect.uchicago.edu",
+    "srmname": "srm://ceph-se.osgconnect.net:8443/srm/v2/server?SFN=/cephfs/srm",
     "dir_raw": "/xenon/xenon1t_test",
     "dir_processed": null,
     "upload_options": [],
     "username": "pdeperio",
-    "download_options": [
-      "midway-login1"
-    ],
+    "download_options": [],
     "pax_processing_versions": null
   },
   {
     "name": "tegner-login-1",
-    "method": "scp",
+    "method": ["scp"],
     "hostname": "tegner-login-1.pdc.kth.se",
     "dir_raw": "/cfs/klemming/projects/xenon/xenon1t/raw",
     "dir_processed": "/cfs/klemming/projects/xenon/xenon1t/processed",
     "upload_options": [],
     "username": "bobau",
-    "download_options": ["xe1t-datamanager","midway-login1"],
+    "download_options": ["xe1t-datamanager","midway"],
     "pax_processing_versions": null
   },
   {
     "name": "xe1t-datamanager",
     "hostname": "xe1t-datamanager.lngs.infn.it",
     "username": "xe1ttransfer",
-    "method": "scp",
+    "method": ["scp"],
     "dir_raw": "/data/xenon/raw",
     "upload_options": [],
     "download_options": [],
@@ -57,42 +57,28 @@
   },
   {
     "name": "lfc",
-    "method": "lcg-cp",
+    "method": ["lcg-cp"],
     "hostname": "lfn:",
     "dir_raw": "/grid/xenon.biggrid.nl/xenon1t/raw",
     "username": null
   },
   {
-    "name": "osg-connect-srm",
-    "method": "lcg-cp",
-    "hostname": "srm://ceph-se.osgconnect.net:8443/srm/v2/server?SFN=",
-    "dir_raw": "/cephfs/srm/xenon/xenon1t",
-    "username": null
-  },
-  {
-    "name": "midway-srm",
-    "method": "lcg-cp",
-    "hostname": "srm://srm1.rcc.uchicago.edu:8443/srm/v2/server?SFN=",
-    "dir_raw": "/project/lgrandi/xenon1t/raw",
-    "username": null
-  },
-  {
     "name": "cnaf-srm",
-    "method": "lcg-cp",
+    "method": ["lcg-cp"],
     "hostname": "srm://storm-fe-archive.cr.cnaf.infn.it:8444/srm/managerv2?SFN=",
     "dir_raw": "/xenon/xenon1t",
     "username": null
   },
   {
     "name": "nikhef-srm",
-    "method": "lcg-cp",
+    "method": ["lcg-cp"],
     "hostname": "srm://tbn18.nikhef.nl:8446/srm/managerv2?SFN=",
     "dir_raw": "/dpm/nikhef.nl/home/xenon.biggrid.nl/xenon1t",
     "username": null
   },
   {
     "name": "wipp-srm",
-    "method": "lcg-cp",
+    "method": ["lcg-cp"],
     "hostname": "srm://wipp-se.weizmann.ac.il",
     "dir_raw": "/xenon/xenon1t",
     "username": null

--- a/cax/config.py
+++ b/cax/config.py
@@ -15,7 +15,7 @@ DATABASE_LOG = True
 HOST = os.environ.get("HOSTNAME") if os.environ.get("HOSTNAME") else socket.gethostname().split('.')[0]
 
 PAX_DEPLOY_DIRS = {
-    'midway-login1' : '/project/lgrandi/deployHQ/pax',
+    'midway' : '/project/lgrandi/deployHQ/pax',
     'tegner-login-1': '/afs/pdc.kth.se/projects/xenon/software/pax'
 }
 
@@ -165,10 +165,10 @@ def data_availability(hostname=get_hostname()):
 
 def processing_script(args={}):
     host = get_hostname()
-    if host not in ('midway-login1', 'tegner-login-1'):
+    if host not in ('midway', 'tegner-login-1'):
         raise ValueError
 
-    midway = (host == 'midway-login1')
+    midway = (host == 'midway')
     default_args = dict(host=host,
                         use='cax',
                         number=333,

--- a/cax/config.py
+++ b/cax/config.py
@@ -188,14 +188,16 @@ def processing_script(args={}):
     # Evaluate {variables} within strings in the arguments.
     args = {k:v.format(**args) if isinstance(v, str) else v for k,v in args.items()}
 
+    os.makedirs(args['base']+"/"+args['use']+"/"+args['number']+"_"+args['pax_version'], exist_ok=True)
+
     # Script parts common to all sites
     script_template = """#!/bin/bash
 #SBATCH --job-name={use}_{number}_{pax_version}
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task={ncpus}
 
-#SBATCH --output={base}/{use}/logs/{number}_{pax_version}_%J.log
-#SBATCH --error={base}/{use}/logs/{number}_{pax_version}_%J.log
+#SBATCH --output={base}/{use}/{number}_{pax_version}/{number}_{pax_version}_%J.log
+#SBATCH --error={base}/{use}/{number}_{pax_version}/{number}_{pax_version}_%J.log
 #SBATCH --account={account}
 #SBATCH --partition={partition}
 

--- a/cax/config.py
+++ b/cax/config.py
@@ -188,7 +188,7 @@ def processing_script(args={}):
     # Evaluate {variables} within strings in the arguments.
     args = {k:v.format(**args) if isinstance(v, str) else v for k,v in args.items()}
 
-    os.makedirs(args['base']+"/"+args['use']+"/"+args['number']+"_"+args['pax_version'], exist_ok=True)
+    os.makedirs(args['base']+"/"+args['use']+("/%d"%args['number'])+"_"+args['pax_version'], exist_ok=True)
 
     # Script parts common to all sites
     script_template = """#!/bin/bash

--- a/cax/main.py
+++ b/cax/main.py
@@ -200,7 +200,7 @@ def massive():
                 logging.info("Skip if exists")
                 continue
 
-            while qsub.get_number_in_queue() > (100 if config.get_hostname() == 'midway-login1' else 30):
+            while qsub.get_number_in_queue() > (100 if config.get_hostname() == 'midway' else 30):
                 logging.info("Speed break 60s because %d in queue" % qsub.get_number_in_queue())
                 time.sleep(60)
 

--- a/cax/qsub.py
+++ b/cax/qsub.py
@@ -93,7 +93,7 @@ def get_queue(host=config.get_hostname()):
     """Get list of jobs in queue"""
 
 
-    if host == "midway-login1":
+    if host == "midway":
         args = {'partition': 'xenon1t',
                 'user' : 'tunnell'}
     elif host == 'tegner-login-1':

--- a/cax/tasks/checksum.py
+++ b/cax/tasks/checksum.py
@@ -25,6 +25,7 @@ class AddChecksum(Task):
 
         # Data must be here locally
         if data_doc['host'] != config.get_hostname():
+            return
 
         # This status is given after checksumming
         status = 'transferred'

--- a/cax/tasks/checksum.py
+++ b/cax/tasks/checksum.py
@@ -26,11 +26,6 @@ class AddChecksum(Task):
         # Data must be here locally
         if data_doc['host'] != config.get_hostname():
 
-            # Special case of midway-srm accessible via POSIX on midway-login1
-            if not (data_doc['host']  == "midway-srm" and config.get_hostname() == "midway-login1"):
-                self.log.debug('Location not here')
-                return
-
         # This status is given after checksumming
         status = 'transferred'
 
@@ -67,7 +62,7 @@ class CompareChecksums(Task):
         # These types of data and location provide master checksum
         master_checksums = (('raw', 'xe1t-datamanager', None),
                             ('raw', 'xenon1t-daq', None),
-                            ('processed', 'midway-login1', pax_version))
+                            ('processed', 'midway', pax_version))
 
         for data_doc in self.run_doc['data']:
 
@@ -101,9 +96,7 @@ class CompareChecksums(Task):
             # Grab main checksum.
             if data_doc['checksum'] != self.get_main_checksum(**data_doc):
 
-                # Special case of midway-srm accessible via POSIX on midway-login1
-                if data_doc['host'] == config.get_hostname() \
-                   or (data_doc['host'] == "midway-srm" and config.get_hostname() == "midway-login1"):
+                if data_doc['host'] == config.get_hostname():
                     error = "Local checksum error " \
                             "run %d" % self.run_doc['number']
                     if warn:

--- a/cax/tasks/data_mover.py
+++ b/cax/tasks/data_mover.py
@@ -233,8 +233,8 @@ class CopyBase(Task):
                 raise
             else:
                 for method in methods:
-                    shutil.which(method) is not None
-                    break
+                    if shutil.which(method) is not None:
+                        break
 
             datum_here, datum_there = self.local_data_finder(data_type,
                                                              option_type,

--- a/cax/tasks/data_mover.py
+++ b/cax/tasks/data_mover.py
@@ -8,6 +8,7 @@ import datetime
 import logging
 import os
 import time
+import shutil
 
 import scp
 from paramiko import SSHClient, util
@@ -48,7 +49,7 @@ class CopyBase(Task):
             raise NotImplementedError()
 
     def copyLCGCP(self, datum_original, datum_destination, server, option_type, nstreams):
-        """Copy data via GFAL function
+        """Copy data via LCG function
         WARNING: Only SRM<->Local implemented (not yet SRM<->SRM)
         """
         dataset = datum_original['location'].split('/').pop()
@@ -220,10 +221,15 @@ class CopyBase(Task):
             self.log.debug(remote_host)
 
             # Get transfer protocol
-            method = config.get_config(remote_host)['method'] 
-            if not method:
+            method = ""
+            methods = config.get_config(remote_host)['method'] 
+            if not methods:
                 print ("Must specify transfer protocol (method) for "+remote_host)
                 raise
+            else:
+                for method in methods:
+                    shutil.which(method) is not None
+                    break
 
             datum_here, datum_there = self.local_data_finder(data_type,
                                                              option_type,

--- a/cax/tasks/data_mover.py
+++ b/cax/tasks/data_mover.py
@@ -22,14 +22,19 @@ class CopyBase(Task):
 
     def copy(self, datum_original, datum_destination, method, option_type):
 
+        if method == 'scp':
+            site_tag = 'hostname'
+        else:
+            site_tag = 'srmname'
+
         if option_type == 'upload':
             config_destination = config.get_config(datum_destination['host'])
-            server = config_destination['hostname']
+            server = config_destination[site_tag]
             username = config_destination['username']
 
         else:
             config_original = config.get_config(datum_original['host'])
-            server = config_original['hostname']
+            server = config_original[site_tag]
             username = config_original['username']
 
         nstreams = 16

--- a/cax/tasks/process.py
+++ b/cax/tasks/process.py
@@ -124,7 +124,7 @@ class ProcessBatchQueue(Task):
 
         thishost = config.get_hostname()
 
-        if thishost != 'midway-login1':
+        if thishost != 'midway':
             return
 
         versions = ['v%s' % pax.__version__]
@@ -196,14 +196,8 @@ class ProcessBatchQueue(Task):
             if 'host' not in datum:
                 continue
 
-            # If the location is Midway SRM...
-            if datum['host']  == "midway-srm":
-                # ... must access from midway-login1
-                if thishost != "midway-login1":
-                    continue
-
             # Otherwise, if the location doesn't refer to here, skip
-            elif datum['host'] != thishost:
+            if datum['host'] != thishost:
                 continue
 
             # Raw data must exist


### PR DESCRIPTION
New features:
- Clean up the way cax handles equivalence between "midway-login1" and "midway-srm"
- Now user must prepend all cax commands with ```HOSTNAME=midway```
- Sites can specify list of copy methods in priority, e.g. lcg-cp, gfal-copy, scp
- Push from xe1t-datamanager to midway via lcg-cp (16 streams currently hardcoded)
  - Simultaneously registers to LFC

**Please see run 28, data 160315_1425 for example run.**

Things still missing:
- Cleanup of LFC replica if necessary (should be impossible because LFC should not be registered if copy fails)
  - Also, LFC-equipped tools not yet available on Midway
- DB entry for LFC entry?