### PR TITLE
Set basic_dir permissions correct for processed data at init

### DIFF
--- a/cax/config.py
+++ b/cax/config.py
@@ -13,6 +13,8 @@ import pymongo
 CAX_CONFIGURE = ''
 DATABASE_LOG = True
 HOST = os.environ.get("HOSTNAME") if os.environ.get("HOSTNAME") else socket.gethostname().split('.')[0]
+DATA_USER_PDC = 'bobau'
+DATA_GROUP_PDC = 'xenon-users'
 
 PAX_DEPLOY_DIRS = {
     'midway-login1' : '/project/lgrandi/deployHQ/pax',
@@ -236,3 +238,17 @@ def get_processing_base_dir(host=get_hostname()):
 def get_processing_dir(host, version):
     return os.path.join(get_processing_base_dir(host),
                         'pax_%s' % version)
+
+def adjust_permission_base_dir(base_dir, destination):
+    """Set ownership and permissons for basic folder of processed data (pax_vX)"""
+
+    if destination=="tegner-login-1":
+      #Change group and set permissions for PDC Stockholm
+      user_group = DATA_USER_PDC + ":" + DATA_GROUP_PDC
+      
+      subprocess.Popen( ["chown", "-R", user_group, base_dir],
+                        stdout=subprocess.PIPE )
+                             
+
+      subprocess.Popen( ["setfacl", "-R", "-M", "/cfs/klemming/projects/xenon/misc/basic", base_dir],
+                        stdout=subprocess.PIPE )

--- a/cax/tasks/data_mover.py
+++ b/cax/tasks/data_mover.py
@@ -310,6 +310,8 @@ class CopyBase(Task):
 
             # Recursively make directories
             os.makedirs(base_dir)
+            # Adjust permissions via config.py
+            config.adjust_permission_base_dir(base_dir, destination)
 
         # Directory or filename to be copied
         filename = datum['location'].split('/')[-1]


### PR DESCRIPTION
Each time we reprocess data with a new pax version the basic directory which is created at the PDC Stockholm (/cfs/klemming/projects/xenon/xenon1t/processed/pax_vX.x.x/) has the wrong permissions. This fix adjust the permissions for Stockholm.

