### PR TITLE
Change path to Anaconda Installation at PDC

### DIFF
--- a/cax/config.py
+++ b/cax/config.py
@@ -179,7 +179,7 @@ def processing_script(args={}):
                         partition='xenon1t' if midway else 'main',
                         base='/project/lgrandi/xenon1t' if midway else '/cfs/klemming/projects/xenon/xenon1t',
                         account='pi-lgrandi' if midway else 'xenon',
-                        anaconda='/project/lgrandi/anaconda3/bin' if midway else '/cfs/klemming/nobackup/b/bobau/ToolBox/TestEnv/Anaconda3/bin',
+                        anaconda='/project/lgrandi/anaconda3/bin' if midway else '/afs/pdc.kth.se/projects/xenon/software/Anaconda3/bin',
                         extra='#SBATCH --mem-per-cpu=2000\n#SBATCH --qos=xenon1t' if midway else '#SBATCH -t 72:00:00',
                         stats='sacct -j $SLURM_JOB_ID --format="JobID,Elapsed,AllocCPUS,CPUTime,MaxRSS"' if midway else '',
                         )


### PR DESCRIPTION
Just a minor adjustment: I changed recently the installation directory at the PDC of the Anaconda installation back to the common xenon1t software folder. I changed the path in cax too.
This change is only important for reprocessing data at Stockholm.