### PR TITLE
Use DAQ API instead of direct database calls

### DIFF
--- a/cax/api.py
+++ b/cax/api.py
@@ -7,6 +7,7 @@ from cax import config
 class api():
     def __init__(self):
 
+        logging.getLogger('requests').setLevel(logging.ERROR)
 
         if ( config.API_URL is None or config.api_user() is None
              or config.api_key() is None or config.DETECTOR is None ):
@@ -73,10 +74,35 @@ class api():
         # BSON/JSON confusion. Get rid of date field.
         if 'creation_time' in parameters:
             parameters.pop('creation_time')
-        parameters=dumps(parameters)
-        ret = requests.put(url, data=parameters,
+        pars=dumps(parameters)
+        ret = requests.put(url, data=pars,
                            headers=self.data_set_headers)
-        
+
+        # This checks to make sure the location was added/removed/updated
+        # GET request
+        params = self.get_params
+        doc = json_util.loads(requests.get(self.api_url+str(uuid),
+                                           params=params).text)['doc']
+
+        # We removed the location
+        if parameters['status'] == 'remove':
+
+            if 'data' not in doc:
+                return True
+            for entry in doc['data']:
+                
+                if self.verify_site(entry, parameters):
+                    print(entry)
+                    print(parameters)
+                    raise RuntimeError("Failed to update run doc")
+        else:
+            if 'data' not in doc:
+                raise RuntimeError("Failed to update run doc")
+            for entry in doc['data']:
+                if self.verify_site(entry, parameters):
+                    return True
+            raise RuntimeError("Failed to update run doc")
+                
     def remove_location(self, uuid, parameters):    
         # Removes a data location from the list        
         parameters['status'] = "remove"
@@ -86,3 +112,10 @@ class api():
         # Removes location from the list then adds a new one
         self.remove_location(uuid, remove_parameters)
         self.add_location(uuid, add_parameters)
+
+    def verify_site(self, sitea, siteb):
+        # We assume two data entries are identical if the host, type,
+        # and path are the same
+        return ( (sitea['host'] == siteb['host']) and
+                 (sitea['type'] == siteb['type']) and
+                 (sitea['location'] == siteb['location']))

--- a/cax/api.py
+++ b/cax/api.py
@@ -12,7 +12,7 @@ class api():
             "api_key": config.api_key(),
             "detector": config.DETECTOR
         }
-        self.next_run = None
+        self.next_run = "init"
 
         # Runs DB writing parameters
         self.data_set_headers = {
@@ -25,9 +25,9 @@ class api():
     def get_next_run(query):
 
         ret = None
-        if self.next_run == "null":
+        if self.next_run == None:
             return ret
-        if self.next_run is None:
+        if self.next_run is "init":
             # Prepare query parameters
             params = self.get_params
             if 'detector' in params and params['detector'] == 'all':
@@ -45,10 +45,11 @@ class api():
 
         # Keep track of the next run so we can iterate. 
         if ret is not None:
-            self.next_run = ret['next']           
+            self.next_run = ret['next']
             return ret['doc']
-        return None
 
+        return None
+    
     def add_location(uuid, parameters):
         # Adds a new data location to the list
 

--- a/cax/api.py
+++ b/cax/api.py
@@ -6,6 +6,12 @@ from cax import config
 
 class api():
     def __init__(self):
+
+
+        if ( config.API_URL is None or config.api_user() is None
+             or config.api_key() is None or config.DETECTOR is None ):
+            raise NameError("API connectivity options not found")
+        
         # Runs DB Query Parameters
         self.api_url = config.API_URL
         self.get_params = {
@@ -24,7 +30,6 @@ class api():
         self.logging = logging.getLogger(self.__class__.__name__)
 
     def get_next_run(self, query):
-
         ret = None
         if self.next_run == None:
             return ret
@@ -51,7 +56,7 @@ class api():
             if len(ret['objects'])==0:
                 return None
             
-            return json_util.loads(ret['objects'][0]['doc'])
+            return ret['objects'][0]['doc']
 
         return None
     

--- a/cax/api.py
+++ b/cax/api.py
@@ -1,0 +1,72 @@
+import requests
+from json import dumps, loads
+
+from cax import config
+
+class api():
+    def __init__(self):
+        # Runs DB Query Parameters
+        self.api_url = config.API_URL
+        self.get_params = {
+            "username": config.api_user(),
+            "api_key": config.api_key(),
+            "detector": config.DETECTOR
+        }
+        self.next_run = None
+
+        # Runs DB writing parameters
+        self.data_set_headers = {
+            "content-type": "application/json",
+            "Authorization": "ApiKey "+config.api_user()+":"+config.api_key()
+        }
+        
+        self.logging = logging.getLogger(self.__class__.__name__)
+
+    def get_next_run(query):
+
+        ret = None
+        if self.next_run == "null":
+            return ret
+        if self.next_run is None:
+            # Prepare query parameters
+            params = self.get_params
+            if 'detector' in params and params['detector'] == 'all':
+                params.pop('detector')
+            for key in query.keys():
+                params[key] = query[key]
+
+            params['limit']=1
+            params['offset']=0
+            
+            ret = requests.get(self.api_url, params = params)
+            
+        else:
+            ret = requests.get(self.next_run)
+
+        # Keep track of the next run so we can iterate. 
+        if ret is not None:
+            self.next_run = ret['next']           
+            return ret['doc']
+        return None
+
+    def add_location(uuid, parameters):
+        # Adds a new data location to the list
+
+        # Parameters must contain certain keys.
+        required = ["host", "location", "checksum", "status", "type"]
+        if not all(key in parameters for key in required):
+            raise NameError("attempt to update location without required keys")
+
+        url = self.api_url + uuid + "/"
+        ret = requests.put(url, data=parameters,
+                           headers=self.data_set_headers)
+        
+    def remove_location(uuid, parameters):    
+        # Removes a data location from the list
+        parameters['status'] = "remove"
+        self.add_location(uuid, parameters)
+        
+    def update_location(uuid, remove_parameters, add_parameters):
+        # Removes location from the list then adds a new one
+        self.remove_location(uuid, remove_parameters)
+        self.add_location(uuid, add_parameters)

--- a/cax/config.py
+++ b/cax/config.py
@@ -16,6 +16,9 @@ HOST = os.environ.get("HOSTNAME") if os.environ.get("HOSTNAME") else socket.geth
 DATA_USER_PDC = 'bobau'
 DATA_GROUP_PDC = 'xenon-users'
 
+DETECTOR = "tpc"
+API_URL = "https://xenon1t-daq.lngs.infn.it/runs_api/runs/runs/"
+
 PAX_DEPLOY_DIRS = {
     'midway-login1' : '/project/lgrandi/deployHQ/pax',
     'tegner-login-1': '/afs/pdc.kth.se/projects/xenon/software/pax'
@@ -133,6 +136,11 @@ def get_task_list():
 
     return options
 
+def api_user():
+    return os.environ.get("API_USER")
+
+def api_key():
+    return os.environ.get("API_KEY")
 
 def mongo_collection(collection_name='runs_new'):
     # For the event builder to communicate with the gateway, we need to use the DAQ network address

--- a/cax/task.py
+++ b/cax/task.py
@@ -1,5 +1,6 @@
 import logging
 from json import dumps, loads
+from bson import json_util
 
 from cax import api
 from cax import config
@@ -71,7 +72,7 @@ class Task():
         This calls peoples and issues a wide range of alarms, so use wisely.
         """
         santized_run_doc = self.run_doc.copy()
-        santized_run_doc = loads(dumps(santized_run_doc))
+        santized_run_doc = loads(json_util.dumps(santized_run_doc))
 
         self.log.error(message)
 

--- a/cax/task.py
+++ b/cax/task.py
@@ -1,7 +1,7 @@
 import logging
 from json import dumps, loads
 
-from api import api
+from cax import api
 from cax import config
 
 
@@ -11,7 +11,7 @@ class Task():
         self.log = logging.getLogger(self.__class__.__name__)
         self.run_doc = None
         self.untriggered_data = None
-        self.api = api()
+        self.api = api.api()
         
     def go(self, specify_run = None):
         """Run this periodically"""

--- a/cax/tasks/checksum.py
+++ b/cax/tasks/checksum.py
@@ -8,7 +8,7 @@ import checksumdir
 
 from cax import config
 from ..task import Task
-
+import copy
 
 class AddChecksum(Task):
     "Perform a checksum on accessible data."
@@ -51,10 +51,14 @@ class AddChecksum(Task):
             self.log.info("Adding a checksum to run "
                           "%d %s" % (self.run_doc['number'],
                                      data_doc['type']))
-            self.collection.update({'_id' : self.run_doc['_id'],
-                                    'data': {'$elemMatch': data_doc}},
-                                   {'$set': {'data.$.status'  : status,
-                                             'data.$.checksum': value}})
+            update_doc = copy.deepcopy(data_doc)
+            update_doc['status'] = status
+            update_doc['checksum'] = value
+            self.api.update_location(self.run_doc['_id'], data_doc, update_doc)            
+            #self.collection.update({'_id' : self.run_doc['_id'],
+            #                        'data': {'$elemMatch': data_doc}},
+            #                       {'$set': {'data.$.status'  : status,
+            #                                 'data.$.checksum': value}})
 
 
 class CompareChecksums(Task):

--- a/cax/tasks/checksum.py
+++ b/cax/tasks/checksum.py
@@ -54,12 +54,8 @@ class AddChecksum(Task):
             update_doc = copy.deepcopy(data_doc)
             update_doc['status'] = status
             update_doc['checksum'] = value
-            self.api.update_location(self.run_doc['_id'], data_doc, update_doc)            
-            #self.collection.update({'_id' : self.run_doc['_id'],
-            #                        'data': {'$elemMatch': data_doc}},
-            #                       {'$set': {'data.$.status'  : status,
-            #                                 'data.$.checksum': value}})
-
+            self.api.update_location(self.run_doc['_id'], data_doc, update_doc)
+            
 
 class CompareChecksums(Task):
     "Perform a checksum on accessible data."

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -44,7 +44,8 @@ class RetryStalledTransfer(checksum.CompareChecksums):
         except FileNotFoundError:
             time_modified = 0
         time_modified = datetime.datetime.fromtimestamp(time_modified)
-        time_made = data_doc['creation_time']        
+        time_made = datetime.datetime.strptime(data_doc['creation_time'][:-7],
+                                               "%Y-%m-%dT%H:%M:%S")
         difference = datetime.datetime.utcnow() - max(time_modified,
                                                       time_made)
 
@@ -78,8 +79,8 @@ class RetryStalledTransfer(checksum.CompareChecksums):
                 self.log.error('did not exist, notify run database.')
 
             if config.DATABASE_LOG == True:
-                resp = self.collection.update({'_id': self.run_doc['_id']},
-                                              {'$pull': {'data': data_doc}})
+                self.api.remove_location(self.run_doc['_id'], data_doc)
+
             self.log.error('Removed from run database.')
             self.log.debug(resp)
 
@@ -120,8 +121,7 @@ class RetryBadChecksumTransfer(checksum.CompareChecksums):
                     self.log.error('did not exist, notify run database.')
 
                 if config.DATABASE_LOG == True:
-                    resp = self.collection.update({'_id': self.run_doc['_id']},
-                                                  {'$pull': {'data': data_doc}})
+                    self.api.remove_location(self.run_doc['_id'], data_doc)
 
                 self.log.error('Removed from run database.')
                 self.log.debug(resp)

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -44,7 +44,7 @@ class RetryStalledTransfer(checksum.CompareChecksums):
         except FileNotFoundError:
             time_modified = 0
         time_modified = datetime.datetime.fromtimestamp(time_modified)
-        time_made = datetime.datetime.strptime(data_doc['creation_time'][:-7],
+        time_made = datetime.datetime.strptime(data_doc['creation_time'][0][:-7],
                                                "%Y-%m-%dT%H:%M:%S")
         difference = datetime.datetime.utcnow() - max(time_modified,
                                                       time_made)

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -44,7 +44,7 @@ class RetryStalledTransfer(checksum.CompareChecksums):
         except FileNotFoundError:
             time_modified = 0
         time_modified = datetime.datetime.fromtimestamp(time_modified)
-        time_made = data_doc['creation_time']
+        time_made = data_doc['creation_time']        
         difference = datetime.datetime.utcnow() - max(time_modified,
                                                       time_made)
 

--- a/cax/tasks/data_mover.py
+++ b/cax/tasks/data_mover.py
@@ -332,11 +332,9 @@ class CopyBase(Task):
                 datum_new[variable] = datum.get(variable)
 
         if config.DATABASE_LOG == True:
-            result = self.api.add_location(self.run_doc['_id'], datum_new)
-            #result = self.collection.update_one({'_id': self.run_doc['_id'],
-            #                                     },
-            #                       {'$push': {'data': datum_new}})
+            self.api.add_location(self.run_doc['_id'], datum_new)
 
+            # Note! Should we account for this race condition?
             #if result.matched_count == 0:
             #    self.log.error("Race condition!  Could not copy because another "
             #                   "process seemed to already start.")
@@ -366,11 +364,7 @@ class CopyBase(Task):
             update_datum = copy.deepcopy(datum_new)
             update_datum['status'] = status
             self.api.update_location(self.run_doc['_id'], datum_new, update_datum)
-            #self.collection.update({'_id' : self.run_doc['_id'],
-            #                        'data': {
-            #                            '$elemMatch': datum_new}},
-            #                       {'$set': {'data.$.status': status}})
-
+            
         self.log.debug(method+" done, telling run database")
 
         self.log.info("End of "+option_type+"\n")

--- a/cax/tasks/data_mover.py
+++ b/cax/tasks/data_mover.py
@@ -331,14 +331,15 @@ class CopyBase(Task):
                 datum_new[variable] = datum.get(variable)
 
         if config.DATABASE_LOG == True:
-            result = self.collection.update_one({'_id': self.run_doc['_id'],
-                                                 },
-                                   {'$push': {'data': datum_new}})
+            result = self.api.add_location(self.run_doc['_id'], datum_new)
+            #result = self.collection.update_one({'_id': self.run_doc['_id'],
+            #                                     },
+            #                       {'$push': {'data': datum_new}})
 
-            if result.matched_count == 0:
-                self.log.error("Race condition!  Could not copy because another "
-                               "process seemed to already start.")
-                return
+            #if result.matched_count == 0:
+            #    self.log.error("Race condition!  Could not copy because another "
+            #                   "process seemed to already start.")
+            #    return
 
         self.log.info('Starting '+method)
 
@@ -361,10 +362,13 @@ class CopyBase(Task):
         self.log.debug(method+" done, telling run database")
 
         if config.DATABASE_LOG:
-            self.collection.update({'_id' : self.run_doc['_id'],
-                                    'data': {
-                                        '$elemMatch': datum_new}},
-                                   {'$set': {'data.$.status': status}})
+            update_datum = datum_new
+            update_datum['status'] = status
+            self.api.update_location(self.run_doc['_id'], datum_new, update_datum)
+            #self.collection.update({'_id' : self.run_doc['_id'],
+            #                        'data': {
+            #                            '$elemMatch': datum_new}},
+            #                       {'$set': {'data.$.status': status}})
 
         self.log.debug(method+" done, telling run database")
 

--- a/cax/tasks/data_mover.py
+++ b/cax/tasks/data_mover.py
@@ -163,6 +163,7 @@ class CopyBase(Task):
     def copySCP(self, datum_original, datum_destination, server, username, option_type):
         """Copy data via SCP function
         """
+
         util.log_to_file('ssh.log')
         ssh = SSHClient()
         ssh.load_system_host_keys()

--- a/cax/tasks/data_mover.py
+++ b/cax/tasks/data_mover.py
@@ -16,6 +16,7 @@ from cax import config
 from cax.task import Task
 
 import subprocess
+import copy
 
 class CopyBase(Task):
 
@@ -317,14 +318,14 @@ class CopyBase(Task):
         filename = datum['location'].split('/')[-1]
 
         self.log.debug("Notifying run database")
-        datum_new = {'type'         : datum['type'],
-                     'host'         : destination,
-                     'status'       : 'transferring',
-                     'location'     : os.path.join(base_dir,
-                                                   filename),
-                     'checksum'     : None,
-                     'creation_time': datetime.datetime.utcnow(),
-                     }
+        datum_new = {
+            'type'         : datum['type'],
+            'host'         : destination,
+            'status'       : 'transferring',
+            'location'     : os.path.join(base_dir,
+                                          filename),
+            'checksum'     : None,            
+        }
 
         if datum['type'] == 'processed':
             for variable in ('pax_version', 'pax_hash', 'creation_place'):
@@ -362,7 +363,7 @@ class CopyBase(Task):
         self.log.debug(method+" done, telling run database")
 
         if config.DATABASE_LOG:
-            update_datum = datum_new
+            update_datum = copy.deepcopy(datum_new)
             update_datum['status'] = status
             self.api.update_location(self.run_doc['_id'], datum_new, update_datum)
             #self.collection.update({'_id' : self.run_doc['_id'],

--- a/cax/tasks/filesystem.py
+++ b/cax/tasks/filesystem.py
@@ -88,10 +88,9 @@ class RenameSingle(Task):
 
             # Notify run database
             if config.DATABASE_LOG is True:
-                self.collection.update({'_id' : self.run_doc['_id'],
-                                        'data': {'$elemMatch': data_doc}},
-                                       {'$set': {
-                                           'data.$.location': self.output}})
+                self.api.update_location(self.run_doc['_id'],
+                                         data_doc, self.output)
+
             break
 
 
@@ -121,8 +120,7 @@ class RemoveSingle(Task):
 
             # Notify run database
             if config.DATABASE_LOG is True:
-                self.collection.update({'_id': self.run_doc['_id']},
-                                       {'$pull': {'data': data_doc}})
+                self.api.remove_location(self.run_doc['_id'], data_doc)
 
             # Perform operation
             self.log.info("Removing %s" % (self.location))


### PR DESCRIPTION
This update replaces most (maybe all) pymongo query and update calls with API methods over the DAQ gateway. It adds a new class (api.py) that now requires API credentials to function. You have to set API_USER and API_KEY as environment variables. Failure to provide these will raise an exception. The whole point of this is to run cax at non-whitelisted sites, like the GRID.

This has been tested for basic transfers only. It would be nice to have some help making sure processing works correctly too. 

There are two points I was unsure of. 
1. Right now there is a check after trying to update the runs DB whether or not this was successful. If the check fails the program immediately dies and raises an exception. Is there a good way to make this more resilient? Otherwise cax may crash every time the connection to the gateway (LNGS) dies. 
2. There's a race condition identified in tasks/clear.py line 340. Can someone clarify if this what happening and what exactly is happening? We can't verify the update in the same way using the API  as we did with the pymongo call, so if this is needed we have to find another way.