### PR TITLE
Reduce pax queue block size in batch processing

### DIFF
--- a/cax/tasks/process.py
+++ b/cax/tasks/process.py
@@ -91,7 +91,7 @@ def _process(name, in_location, host, pax_version, pax_hash,
         pax_kwargs = dict(config_names=pax_config,
                           config_dict={'pax': {'input_name' : in_location,
                                                'output_name': output_fullname},
-                                       'Queues': {'event_block_size': }})
+                                       'Queues': {'event_block_size': 1}})
         if ncpus > 1:
             parallel.multiprocess_locally(n_cpus=ncpus, **pax_kwargs)
         else:

--- a/cax/tasks/process.py
+++ b/cax/tasks/process.py
@@ -91,7 +91,7 @@ def _process(name, in_location, host, pax_version, pax_hash,
         pax_kwargs = dict(config_names=pax_config,
                           config_dict={'pax': {'input_name' : in_location,
                                                'output_name': output_fullname},
-                                       'Queues': {'max_queue_blocks': 50}})
+                                       'Queues': {'event_block_size': }})
         if ncpus > 1:
             parallel.multiprocess_locally(n_cpus=ncpus, **pax_kwargs)
         else:


### PR DESCRIPTION
Pax by default groups events in blocks of 10 when it puts them on internal/remote queues. On midway we process XENON1T events at a few events/sec (for which 4 CPUs have to work together), so this block grouping doesn't help performance. Moreover, it increases the memory requirement of pax and increases the possibility of timeouts (when a few very large events choke the workers).