### PR TITLE
New purge rules for Rn220/Kr83m

### DIFF
--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -109,9 +109,14 @@ class BufferPurger(checksum.CompareChecksums):
             self.log.debug("Do not purge processed data")
             return
 
-        if self.run_doc['source']['type'] == "Kr83m" or self.run_doc['source']['type'] == "Rn220":
-            self.log.debug("Do not purge %s data" % self.run_doc['source']['type'])
-            return
+        if data_doc['host'] == 'midway-login1':
+            print("I'm in Midway")
+            if self.run_doc['source']['type'] == "Kr83m" or self.run_doc['source']['type'] == "Rn220":
+                self.log.debug("Do not purge %s data" % self.run_doc['source']['type'])
+                return
+        else:
+            print("I'm not in Midway")
+            print(data_doc['host']) 
         
         self.log.debug("Checking purge logic")
 

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -110,13 +110,9 @@ class BufferPurger(checksum.CompareChecksums):
             return
 
         if data_doc['host'] == 'midway-login1':
-            print("I'm in Midway")
             if self.run_doc['source']['type'] == "Kr83m" or self.run_doc['source']['type'] == "Rn220":
                 self.log.debug("Do not purge %s data" % self.run_doc['source']['type'])
                 return
-        else:
-            print("I'm not in Midway")
-            print(data_doc['host']) 
         
         self.log.debug("Checking purge logic")
 


### PR DESCRIPTION
It prevent the purge process for Rn220 and Kr83m dataset in Midway-login1, while they are purged in the other hosts.