### PR TITLE
Add other treemakers to process_hax

### DIFF
--- a/cax/tasks/process_hax.py
+++ b/cax/tasks/process_hax.py
@@ -32,6 +32,7 @@ def verify():
     """
     return True
 
+
 def _process_hax(name, in_location, host, pax_version,
              out_location, detector='tpc'):
     """Called by another command.
@@ -50,12 +51,12 @@ def _process_hax(name, in_location, host, pax_version,
 
     try:
         print('creating hax minitrees', name, in_location)
-        init_hax(in_location, pax_version, out_location) # may initilize once only
-        hax.minitrees.load(name, ['Basics','Fundamentals'])
+        init_hax(in_location, pax_version, out_location)   # may initialize once only
+        hax.minitrees.load(name, ['Basics', 'Fundamentals',
+                                  'DoubleScatter', 'LargestPeakProperties', 'TotalProperties'])
 
     except Exception as exception:
         raise
-
 
 
 class ProcessBatchQueueHax(Task):

--- a/cax/tasks/process_hax.py
+++ b/cax/tasks/process_hax.py
@@ -20,7 +20,6 @@ from cax.task import Task
 
 
 def init_hax(in_location, pax_version, out_location):
-    print ("TEST PAX version format:  "+pax_version)
     hax.init(experiment='XENON1T',
          main_data_paths=[in_location+'pax_'+pax_version],
          minitree_paths = [out_location])
@@ -50,7 +49,7 @@ def _process_hax(name, in_location, host, pax_version,
     os.makedirs(out_location, exist_ok=True)
 
     try:
-        print('creating hax minitrees', name, in_location)
+        self.log.info('creating hax minitrees', name, in_location)
         init_hax(in_location, pax_version, out_location)   # may initialize once only
         hax.minitrees.load(name, ['Basics', 'Fundamentals',
                                   'DoubleScatter', 'LargestPeakProperties', 'TotalProperties'])
@@ -74,7 +73,6 @@ class ProcessBatchQueueHax(Task):
             return
 
         version = 'v%s' % pax.__version__
-        print ("TEST PAX Version format here: "+version)
         have_processed, have_raw = self.local_data_finder(thishost,
                                                           version)
 


### PR DESCRIPTION
This adds other common treemakers to process_hax:
  * TotalProperties: https://github.com/XENON1T/hax/pull/40, which calculates amongst others the total area in all peaks;
  * DoubleScatter, Ted's treemaker used especially for Kr83m analysis: https://github.com/XENON1T/hax/pull/36;
  * LargestPeakProperties: an older treemaker that may still be useful for studying lone-S2 and lone-S1 events.