### PR TITLE
Don't purge errored data promptly

### DIFF
--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -53,8 +53,7 @@ class RetryStalledTransfer(checksum.CompareChecksums):
                                           self.run_doc['number'],
                                           self.run_doc['name']))
 
-        if difference > datetime.timedelta(hours=24) or \
-                        data_doc["status"] == 'error':  # If stale transfer
+        if difference > datetime.timedelta(hours=24):  # If stale transfer
             self.give_error("Transfer lasting more than 24 hours "
                             "or errored, retry.")
 


### PR DESCRIPTION
This makes cax wait 24 hours to purge errored data since @coderdj didn't like that it was clearing data when DAQ crashed.