### PR TITLE
Switch to run on Midway2

### DIFF
--- a/cax/cax.json
+++ b/cax/cax.json
@@ -24,6 +24,19 @@
     "grid_cert": "/project/lgrandi/deployHQ/cax/user_cert"
   },
   {
+    "name": "midway2-login1.rcc.local",
+    "method": "scp",
+    "hostname": "midway2-login1.rcc.uchicago.edu",
+    "dir_raw": "/project2/lgrandi/xenon1t/raw",
+    "dir_processed": "/project/lgrandi/xenon1t/processed",
+    "dir_minitrees": "/project/lgrandi/xenon1t/minitrees",
+    "upload_options": [],
+    "username": "tunnell",
+    "download_options": ["xe1t-datamanager"],
+    "purge" : 25,
+    "grid_cert": "/project/lgrandi/deployHQ/cax/user_cert"
+  },
+  {
     "name": "login",
     "method": "gfal-copy",
     "hostname": "gsiftp://gridftp.grid.uchicago.edu:2811/cephfs/srm",

--- a/cax/config.py
+++ b/cax/config.py
@@ -16,11 +16,6 @@ HOST = os.environ.get("HOSTNAME") if os.environ.get("HOSTNAME") else socket.geth
 DATA_USER_PDC = 'bobau'
 DATA_GROUP_PDC = 'xenon-users'
 
-PAX_DEPLOY_DIRS = {
-    'midway-login1' : '/project/lgrandi/deployHQ/pax',
-    'tegner-login-1': '/afs/pdc.kth.se/projects/xenon/software/pax'
-}
-
 
 def mongo_password():
     """Fetch passsword for MongoDB
@@ -180,10 +175,10 @@ def data_availability(hostname=get_hostname()):
 
 def processing_script(args={}):
     host = get_hostname()
-    if host not in ('midway-login1', 'tegner-login-1'):
+    if host not in ('midway-login1', 'midway2-login1.rcc.local', 'tegner-login-1'):
         raise ValueError
 
-    midway = (host == 'midway-login1')
+    midway = all(x in config.get_hostname() for x in ["midway", "login1"])
     default_args = dict(host=host,
                         use='cax',
                         number=333,

--- a/cax/main.py
+++ b/cax/main.py
@@ -243,7 +243,7 @@ def massive():
                 logging.debug('Skip: cax_%s_v%s job exists' % (job_name, pax.__version__))
                 continue
 
-            while qsub.get_number_in_queue() > (500 if config.get_hostname() == 'midway-login1' else 30):
+            while qsub.get_number_in_queue() > (500 if all(x in config.get_hostname() for x in ["midway", "login1"]) else 30):
                 logging.info("Speed break 60s because %d in queue" % qsub.get_number_in_queue())
                 time.sleep(60)
 
@@ -444,7 +444,8 @@ def massive_tsmclient():
       
     # Setup logging
     log_path = {"xe1t-datamanager": "/home/xe1ttransfer/tsm_log",
-                "midway-login1": "n/a"}
+                "midway-login1": "n/a",
+                "midway2-login1.rcc.local": "n/a"}
     
     if log_path[config.get_hostname()] == "n/a":
         print("Modify the log path in main.py")

--- a/cax/qsub.py
+++ b/cax/qsub.py
@@ -93,7 +93,7 @@ def get_queue(host=config.get_hostname()):
     """Get list of jobs in queue"""
 
 
-    if host == "midway-login1":
+    if all(x in host for x in ["midway", "login1"]):
         args = {'partition': 'xenon1t',
                 'user' : 'tunnell'}
     elif host == 'tegner-login-1':

--- a/cax/tasks/checksum.py
+++ b/cax/tasks/checksum.py
@@ -36,11 +36,8 @@ class AddChecksum(Task):
 
         # Data must be here locally
         if data_doc['host'] != config.get_hostname():
-
-            # Special case of midway-srm accessible via POSIX on midway-login1
-            if not (data_doc['host']  == "midway-srm" and config.get_hostname() == "midway-login1"):
-                self.log.debug('Location not here')
-                return
+            self.log.debug('Location not here')
+            return
 
         # This status is given after checksumming
         status = 'transferred'

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -110,7 +110,7 @@ class BufferPurger(checksum.CompareChecksums):
             self.log.debug("Do not purge processed data")
             return
 
-        if data_doc['host'] == 'midway-login1':
+        if all(x in data_doc['host'] for x in ["midway", "login1"]): 
             if self.run_doc['source']['type'] == "Kr83m" or self.run_doc['source']['type'] == "Rn220":
                 self.log.debug("Do not purge %s data" % self.run_doc['source']['type'])
                 return

--- a/cax/tasks/corrections.py
+++ b/cax/tasks/corrections.py
@@ -128,9 +128,9 @@ class AddGains(CorrectionBase):
     correction_units = units.V  # should be 1
 
     def each_run(self):
-        """Only run on data manager at LNGS
+        """Only run on Midway
         """
-        if config.get_hostname() == 'midway-login1':
+        if all(x in config.get_hostname() for x in ["midway", "login1"]): 
             CorrectionBase.each_run(self)
 
     def evaluate(self):

--- a/cax/tasks/filesystem.py
+++ b/cax/tasks/filesystem.py
@@ -19,19 +19,24 @@ class SetPermission(Task):
     def __init__(self):
         
         self.raw_data = {"tegner-login-1": "/cfs/klemming/projects/xenon/xenon1t/raw/",
-                    "midway-login1": "/project/lgrandi/xenon1t/raw/"}
+                    "midway-login1": "/project/lgrandi/xenon1t/raw/",
+                    "midway2-login1.rcc.local": "/project2/lgrandi/xenon1t/raw/"}
         
         self.proc_data = {"tegner-login-1": "/cfs/klemming/projects/xenon/xenon1t/processed/",
-                    "midway-login1": "/project/lgrandi/xenon1t/processed/"}
+                    "midway-login1": "/project/lgrandi/xenon1t/processed/",
+                    "midway2-login1.rcc.local": "/project/lgrandi/xenon1t/processed/"}
         
         self.chown_user = {"tegner-login-1": "bobau",
-                           "midway-login1": "tunnell"}
+                           "midway-login1": "tunnell",
+                           "midway2-login1.rcc.local": "tunnell"}
         
         self.chown_group = {"tegner-login-1": "xenon-users",
-                            "midway-login1": "xenon1t-admins"}
+                            "midway-login1": "xenon1t-admins",
+                            "midway2-login1.rcc.local": "xenon1t-admins"}
         
         self.chmod = {"tegner-login-1": '750',
-                      "midway-login1": '755'}
+                      "midway-login1": '755',
+                      "midway2-login1.rcc.local": '755'}
 
         Task.__init__(self)
         self.hostname_config = config.get_config(config.get_hostname())
@@ -44,6 +49,7 @@ class SetPermission(Task):
             if 'host' not in data_doc or data_doc['host'] != config.get_hostname():
                 continue
             
+            midway = all(x in config.get_hostname() for x in ["midway", "login1"])
 
             #extract path:
             f_path = data_doc['location']
@@ -55,7 +61,7 @@ class SetPermission(Task):
               logging.info('Change to username %s and group %s', self.chown_user[self.hostname], self.chown_group[self.hostname])
               logging.info('Set permission: %s', self.chmod[self.hostname] )
               logging.info('Set ownership and permissions at %s', config.get_hostname() )
-              if config.get_hostname() == "midway-login1":
+              if midway:
                 subprocess.call(['chmod', self.chmod[self.hostname], f_path])
                 subprocess.call(['chown', str(self.chown_user[self.hostname]+":"+self.chown_group[self.hostname]), f_path])
               elif config.get_hostname() == "tegner-login-1":
@@ -69,7 +75,7 @@ class SetPermission(Task):
               logging.info('Change to username %s and group %s', self.chown_user[self.hostname], self.chown_group[self.hostname])
               logging.info('Set permission: %s', self.chmod[self.hostname] )
               logging.info('Set ownership and permissions at %s', config.get_hostname() )
-              if config.get_hostname() == "midway-login1":
+              if midway:
                 subprocess.call(['chmod', '-R', self.chmod[self.hostname], f_path])
                 subprocess.call(['chown', '-R', str(self.chown_user[self.hostname]+":"+self.chown_group[self.hostname]), f_path])
               elif config.get_hostname() == "tegner-login-1":

--- a/cax/tasks/process.py
+++ b/cax/tasks/process.py
@@ -150,7 +150,7 @@ class ProcessBatchQueue(Task):
 
         thishost = config.get_hostname()
 
-        if thishost != 'midway-login1':
+        if all(x in thishost for x in ["midway", "login1"]):
             return
 
         versions = ['v%s' % pax.__version__]

--- a/cax/tasks/process_hax.py
+++ b/cax/tasks/process_hax.py
@@ -69,7 +69,7 @@ class ProcessBatchQueueHax(Task):
 
         thishost = config.get_hostname()
         
-        if thishost != 'midway-login1':
+        if not all(x in thishost for x in ["midway", "login1"]):
             return
 
         version = 'v%s' % pax.__version__


### PR DESCRIPTION
/project2 mounting on Midway1 seems unstable, so may need to run from Midway2 (unless our nodes can see it already even though jobs were submitted from Midway1; I haven't checked this).

Anyway, in case we switch to Midway2 (should be eventually):
- Several hardcoded places that check if running on Midway should now be generalized for Midway2. 
- Only raw data set to transfer to /project2 in cax.json for now
  - Processed data to be decided

Partially fixes #70 