### PR TITLE
Implement rsync

### DIFF
--- a/cax/cax.json
+++ b/cax/cax.json
@@ -49,7 +49,7 @@
     "name": "xe1t-datamanager",
     "hostname": "xe1t-datamanager.lngs.infn.it",
     "username": "xe1ttransfer",
-    "method": "scp",
+    "method": "rsync",
     "dir_raw": "/data/xenon/raw/",
     "dir_tsm": "/data/xenon/tsm/",
     "upload_options": null,

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -53,13 +53,17 @@ class RetryStalledTransfer(checksum.CompareChecksums):
                                           self.run_doc['number'],
                                           self.run_doc['name']))
 
+        # Do not delete stalled or failed raw data transfers to recover with rsync 
+        # (Warning: do no use scp, which may create nested directories)
+        delete_data = (data_doc['type'] == 'processed')
+
         if difference > datetime.timedelta(hours=24):
             self.give_error("Transfer lasting more than 24 hours, retry.")
-            self.purge(data_doc)
+            self.purge(data_doc, delete_data)
             
         elif data_doc["status"] == 'error' and data_doc['host'] != 'xe1t-datamanager':
             self.give_error("Transfer or process errored, retry.")
-            self.purge(data_doc)
+            self.purge(data_doc, delete_data)
 
 class RetryBadChecksumTransfer(checksum.CompareChecksums):
     """Alert if stale transfer.


### PR DESCRIPTION
Implement ```rsync``` mode for data transfers for capability to resume stalled or failed transfers, instead of purging and starting from the beginning. ```rsync``` should also provide better throughput than ```scp```.

```purge``` function needed to be changed to prevent the deletion of raw data in these cases, but be warned that scp will now create undesired nested directories without this prior cleanup.