### PR TITLE
Compute drift velocity for each run

### DIFF
--- a/cax/main.py
+++ b/cax/main.py
@@ -95,6 +95,7 @@ def main():
     tasks = [
         corrections.AddElectronLifetime(),  # Add electron lifetime to run, which is just a function of calendar time
         corrections.AddGains(), #  Adds gains to a run, where this is computed using slow control information
+        corrections.AddDriftVelocity(), #  Adds drift velocity to the run, also computed from slow control info
         #corrections.AddSlowControlInformation(),  
         data_mover.CopyPull(), # Download data through e.g. scp to this location
         data_mover.CopyPush(),  # Upload data through e.g. scp or gridftp to this location where cax running

--- a/cax/tasks/corrections.py
+++ b/cax/tasks/corrections.py
@@ -129,32 +129,6 @@ class AddDriftVelocity(CorrectionBase):
         return (41.9527213 * dv - 434.23)**0.0670935
 
 
-class AddSlowControlInformation(CorrectionBase):
-    """Add all slow control highlight information to run db
-    """
-    key = 'slow_control'
-    correction_units = 1
-
-    def get_correction(self):
-        pass
-
-    def evaluate(self):
-        raise NotImplementedError("hax's slow control interface has changed. The code below would crash if you tried to"
-                                  "run it.")
-        time_range = self.get_time_range()
-
-        data = defaultdict(dict)
-        for key1, value1 in slow_control.VARIABLES.items():
-            for key2, value2 in value1.items():
-                series = slow_control.get_series(value2, time_range)
-                if len(series):
-                    data[key1][key2] = float(series.iloc[0])
-                else:
-                    data[key1][key2] = np.nan
-
-        return data
-
-
 class AddGains(CorrectionBase):
     """Copy data to here
 

--- a/cax/tasks/process.py
+++ b/cax/tasks/process.py
@@ -144,6 +144,7 @@ class ProcessBatchQueue(Task):
 
         processing_parameters = self.run_doc['processor']['DEFAULT']
         if 'gains' not in processing_parameters or \
+            'drift_velocity_liquid' not in processing_parameters or \
             'electron_lifetime_liquid' not in processing_parameters:
             self.log.info("gains or e-lifetime not in run_doc, skip processing")
             return

--- a/cax/tasks/process_hax.py
+++ b/cax/tasks/process_hax.py
@@ -21,8 +21,8 @@ from cax.task import Task
 
 def init_hax(in_location, pax_version, out_location):
     hax.init(experiment='XENON1T',
-         main_data_paths=[in_location+'pax_'+pax_version],
-         minitree_paths = [out_location])
+             main_data_paths=[in_location+'pax_'+pax_version],
+             minitree_paths = [out_location])
 
 def verify():
     """Verify the file


### PR DESCRIPTION
We have taken runs at several different drift fields, and therefore different drift velocities. Pax needs to know the drift velocity to compute the z-position of an interaction (and thus the S1(x,y,z) correction). Currently the drift velocity is simply hardcoded in the pax configuration.

This adds a hax task to compute the drift velocity for each run based on the cathode voltage. Almost all runs should fall exactly on one of the datapoints in [my diffusion and drift note](https://xecluster.lngs.infn.it/dokuwiki/doku.php?id=xenon:xenon1t:aalbers:drift_and_diffusion#results). For the few runs which might not, we compute the drift velocity on a power-law fit:

![vdrift_fit](https://cloud.githubusercontent.com/assets/4354311/22405698/caf6da62-e646-11e6-8bb8-3ef57eac45b3.png)

The error bars on the measurements are not very large, see the note linked above.

Naturally we should not rely on this or any fit for many runs: it's trivial to measure the drift velocity at whatever setting we want to do serious analysis in. Nonetheless, it's good to have a decent value for the first time we process runs at a different field.

For fields far outside the measured range (e.g. when the cathode is off) we can't sensibly compute a drift velocity; I instead put a placeholder value, different depending on whether the value is far below the range. It might have been preferably to just disable some pax plugins relying on z-reconstruction, but that's more complicated. Such runs should be clearly tagged anyway.

Unfortunately I have no idea how to test this, or if we can test this at all prior to deployment. I've tested things in fragments but testing the integration with the rest of cax requires a functional setup. 