### PR TITLE
Add gains for acquisition monitor channels

### DIFF
--- a/cax/tasks/corrections.py
+++ b/cax/tasks/corrections.py
@@ -178,6 +178,9 @@ class AddGains(CorrectionBase):
                                             })
             gains.append(float(gain) * self.correction_units)
 
+        # Add gains for acquisition monitor channels
+        gains += [2.5e6 / 31.25] + [1e5] * 5
+            
         return gains
 
 


### PR DESCRIPTION
Without this pax gives an indexerror when processing. In the future we should fetch this from the default XENON1T.ini rather than hardcode it.