### PR TITLE
Remove "bonus" drift velocity function

### DIFF
--- a/cax/tasks/corrections.py
+++ b/cax/tasks/corrections.py
@@ -122,12 +122,6 @@ class AddDriftVelocity(CorrectionBase):
         cathode_v = np.clip(cathode_v, 7, 20)
         return (42.2266 * cathode_v - 268.6557)**0.067018
 
-    @staticmethod
-    def vd(dv_kv):
-        dv = np.asarray(dv_kv).copy()
-        dv = np.clip(dv, 12, 25)
-        return (41.9527213 * dv - 434.23)**0.0670935
-
 
 class AddGains(CorrectionBase):
     """Copy data to here


### PR DESCRIPTION
#75 accidentally contained two drift velocity functions after another. Unfortunately the incorrect one was last, and all our runs are now being processed with the wrong drift velocity. 

This removes the spurious extra function. The remaining one is correct: 
(42.2266 *12 - 268.6557)**0.067018 = 1.4429, which is within the error of the value (1.440) determined  in https://xecluster.lngs.infn.it/dokuwiki/doku.php?id=xenon:xenon1t:aalbers:drift_and_diffusion#results

Thanks to @lgrandi for spotting the z vs dt offset.