### PR TITLE
Add Extended minitree to auto-computed minitrees

### DIFF
--- a/cax/tasks/process_hax.py
+++ b/cax/tasks/process_hax.py
@@ -53,7 +53,7 @@ def _process_hax(name, in_location, host, pax_version,
         init_hax(in_location, pax_version, out_location)   # may initialize once only
         hax.minitrees.load(name, ['Basics', 'Fundamentals',
                                   'DoubleScatter', 'LargestPeakProperties',
-                                  'TotalProperties', 'Proximity'])
+                                  'TotalProperties',  'Extended', 'Proximity'])
 
     except Exception as exception:
         raise


### PR DESCRIPTION
This adds the Extended minitree, which contains variables needed for several sciencerun0 cuts, to the list of auto-computed minitrees.