### PR TITLE
Purge processed root files implemented on the last cax version

### DIFF
--- a/cax/config.py
+++ b/cax/config.py
@@ -81,6 +81,17 @@ def load():
 
     return json.loads(open(filename, 'r').read())
 
+
+def purge_version(hostname=get_hostname()):
+    """
+    You can select which pax version you want purge
+    in this way "vX.x.x" where X is the main pax version
+    and x.x are the different relase. i.e. pax_v1.2.3
+    """
+    return get_config(hostname).get('pax_version_purge',
+                                            None)
+
+
 def purge_settings(hostname=get_hostname()):
     return get_config(hostname).get('purge',
                                     None)

--- a/cax/main.py
+++ b/cax/main.py
@@ -112,6 +112,8 @@ def main():
         checksum.AddChecksum(),  # Add checksum for data here so can know if corruption (useful for knowing when many good copies!)
 
         filesystem.SetPermission(),  # Set any permissions (primarily for Tegner) for new data to make sure analysts can access
+
+        clear.PurgeProcessed(),  # Clear the processed data specifying the pax version of processed files to remove        
         # clear.BufferPurger(),  # Clear old data at some locations as specified in cax.json
         process.ProcessBatchQueue(),  # Process the data with pax
         process_hax.ProcessBatchQueueHax()  # Process the data with hax

--- a/cax/main.py
+++ b/cax/main.py
@@ -113,7 +113,7 @@ def main():
 
         filesystem.SetPermission(),  # Set any permissions (primarily for Tegner) for new data to make sure analysts can access
 
-        clear.PurgeProcessed(),  # Clear the processed data specifying the pax version of processed files to remove        
+        clear.PurgeProcessed(), # Clear the processed data for a given version          
         # clear.BufferPurger(),  # Clear old data at some locations as specified in cax.json
         process.ProcessBatchQueue(),  # Process the data with pax
         process_hax.ProcessBatchQueueHax()  # Process the data with hax

--- a/cax/main.py
+++ b/cax/main.py
@@ -113,7 +113,7 @@ def main():
 
         filesystem.SetPermission(),  # Set any permissions (primarily for Tegner) for new data to make sure analysts can access
 
-        clear.PurgeProcessed(), # Clear the processed data for a given version          
+        clear.PurgeProcessed(), #Clear the processed data for a given version
         # clear.BufferPurger(),  # Clear old data at some locations as specified in cax.json
         process.ProcessBatchQueue(),  # Process the data with pax
         process_hax.ProcessBatchQueueHax()  # Process the data with hax

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -203,8 +203,7 @@ class PurgeProcessed(checksum.CompareChecksums):
 
         # See if purge settings specified, otherwise don't purge
         if not config.purge_version() or (config.purge_version() == None) :
-            self.log.debug("Please set a pax version: vx.x.x")
-            self.log.debug("No purge version has been set")
+            self.log.debug("No processed version specified for purge, skipping")
             return
 
         # Do not purge processed data

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -203,7 +203,7 @@ class PurgeProcessed(checksum.CompareChecksums):
 
         # See if purge settings specified, otherwise don't purge
         if not config.purge_version() or (config.purge_version() == None) :
-            self.log.warning("Please set a pax version: vx.x.x") 
+            self.log.warning("Please set a pax version: vx.x.x")
             self.log.debug("No purge version has been set")
             return
 
@@ -217,7 +217,7 @@ class PurgeProcessed(checksum.CompareChecksums):
             self.log.debug("Don't purge this version: %s" % (data_doc['pax_version']) )
             return
 
-        # The purge data 
+        # The purge data
         self.log.info("Purging %s" % data_doc['location'])
         self.purge(data_doc)
         

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -201,7 +201,7 @@ class PurgeProcessed(checksum.CompareChecksums):
 
         # See if purge settings specified, otherwise don't purge
         if not config.purge_version() or (config.purge_version() == None) :
-            print("Please set a pax version: vx.x.x ") 
+            self.log.info("Please set a pax version: vx.x.x") 
             self.log.debug("No purge version has been set")
             return
 
@@ -213,7 +213,7 @@ class PurgeProcessed(checksum.CompareChecksums):
 
 
         if (data_doc['pax_version'] != config.purge_version()) :
-            self.log.debug("Don't purge this version: %s " % (data_doc['pax_version']) )
+            self.log.debug("Don't purge this version: %s" % (data_doc['pax_version']) )
             return
         # Warning: if you want to enable this here, need to add pax version checking in check() 
 

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -200,10 +200,10 @@ class PurgeProcessed(checksum.CompareChecksums):
         # Skip places where we can't locally access data
         if 'host' not in data_doc or data_doc['host'] != config.get_hostname():
             return
-            print
+
         # See if purge settings specified, otherwise don't purge
         if not config.purge_version() or (config.purge_version() == None) :
-            self.log.info("Please set a pax version: vx.x.x") 
+            self.log.warning("Please set a pax version: vx.x.x") 
             self.log.debug("No purge version has been set")
             return
 
@@ -217,7 +217,7 @@ class PurgeProcessed(checksum.CompareChecksums):
             self.log.debug("Don't purge this version: %s" % (data_doc['pax_version']) )
             return
 
-        # The dt we require
+        # The purge data 
         self.log.info("Purging %s" % data_doc['location'])
         self.purge(data_doc)
         

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -195,10 +195,12 @@ class PurgeProcessed(checksum.CompareChecksums):
         """
         Check every location with data whether it should be purged.
         """
+        self.log.debug("Checking purge logic")
+
         # Skip places where we can't locally access data
         if 'host' not in data_doc or data_doc['host'] != config.get_hostname():
             return
-
+            print
         # See if purge settings specified, otherwise don't purge
         if not config.purge_version() or (config.purge_version() == None) :
             self.log.info("Please set a pax version: vx.x.x") 
@@ -206,29 +208,18 @@ class PurgeProcessed(checksum.CompareChecksums):
             return
 
         # Do not purge processed data
-
         if data_doc['type'] == 'raw':
            self.log.debug("Do not purge raw data")
            return
 
-
+        # Check pax version of processed run
         if (data_doc['pax_version'] != config.purge_version()) :
             self.log.debug("Don't purge this version: %s" % (data_doc['pax_version']) )
             return
-        # Warning: if you want to enable this here, need to add pax version checking in check() 
-
-
-        self.log.debug("Checking purge logic")
-
-        # Only purge transfered data
-        if data_doc["status"] != "transferred":
-            self.log.debug("No processed")
-            return
 
         # The dt we require
-        if (data_doc['pax_version'] == config.purge_version() and data_doc['host'] == 'midway-login1' ):
-            self.log.info("Purging %s" % data_doc['location'])
-            self.purge(data_doc)
-        else:
-            return
+        self.log.info("Purging %s" % data_doc['location'])
+        self.purge(data_doc)
+        
+        return
 

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -203,7 +203,7 @@ class PurgeProcessed(checksum.CompareChecksums):
 
         # See if purge settings specified, otherwise don't purge
         if not config.purge_version() or (config.purge_version() == None) :
-            self.log.warning("Please set a pax version: vx.x.x")
+            self.log.debug("Please set a pax version: vx.x.x")
             self.log.debug("No purge version has been set")
             return
 


### PR DESCRIPTION
To use the new task you must add in the *.json file a new entry to specify the pax version that you want to purge:
` [`
`   {`
`     "name": "midway-login1",`
`     "method": "scp",`
`     "hostname": "midway-login1.rcc.uchicago.edu",`
`     "dir_raw": "/project/lgrandi/xenon1t/raw",`
`     "dir_processed": "/project/lgrandi/xenon1t/processed",`
`     "upload_options": [],`
`     "username": "tunnell",`
`     "download_options": [],`
`     "task_list": ["PurgeProcessed"],`
`     "purge" : 2,`
`     "pax_version_purge" : "v6.1.0"`
`   }`
` ]`
`