### PR TITLE
Purge updates (for Midway)

### DIFF
--- a/cax/main.py
+++ b/cax/main.py
@@ -114,9 +114,9 @@ def main():
         filesystem.SetPermission(),  # Set any permissions (primarily for Tegner) for new data to make sure analysts can access
 
         process.ProcessBatchQueue(),  # Process the data with pax
-        process_hax.ProcessBatchQueueHax()  # Process the data with hax
+        process_hax.ProcessBatchQueueHax(),  # Process the data with hax
         clear.PurgeProcessed(), #Clear the processed data for a given version
-        clear.BufferPurger(),  # Clear old data at some locations as specified in cax.json
+        clear.BufferPurger()  # Clear old data at some locations as specified in cax.json
     ]
 
     # Raises exception if unknown host

--- a/cax/main.py
+++ b/cax/main.py
@@ -113,11 +113,10 @@ def main():
 
         filesystem.SetPermission(),  # Set any permissions (primarily for Tegner) for new data to make sure analysts can access
 
-        clear.PurgeProcessed(), #Clear the processed data for a given version
-        clear.BufferPurger(),  # Clear old data at some locations as specified in cax.json
-
         process.ProcessBatchQueue(),  # Process the data with pax
         process_hax.ProcessBatchQueueHax()  # Process the data with hax
+        clear.PurgeProcessed(), #Clear the processed data for a given version
+        clear.BufferPurger(),  # Clear old data at some locations as specified in cax.json
     ]
 
     # Raises exception if unknown host

--- a/cax/tasks/checksum.py
+++ b/cax/tasks/checksum.py
@@ -146,8 +146,12 @@ class CompareChecksums(Task):
                             'checksum' not in data_doc:
                 continue
 
-            # Grab main checksum.
-            if data_doc['checksum'] != self.get_main_checksum(**data_doc):
+            # Rucio stores its own checksum, assume "transferred" is 1 good copy
+            if data_doc['host'] == 'rucio-catalogue':
+                n += 1
+
+            # Grab main checksum and compare
+            elif data_doc['checksum'] != self.get_main_checksum(**data_doc):
 
                 if data_doc['host'] == config.get_hostname():
                     error = "Local checksum error " \
@@ -155,6 +159,8 @@ class CompareChecksums(Task):
                                             data_doc['pax_version'])
                     if warn:
                         self.give_error(error)
+
+            # Comparison did not fail so add 1 good copy
             else:
                 n += 1
 

--- a/cax/tasks/data_mover.py
+++ b/cax/tasks/data_mover.py
@@ -17,6 +17,7 @@ import pax
 from cax import config
 from cax.task import Task
 from cax import qsub
+from cax.tasks.clear import BufferPurger
 
 from cax.tasks.tsm_mover import TSMclient
 from cax.tasks.rucio_mover import RucioBase, RucioRule
@@ -299,6 +300,13 @@ class CopyBase(Task):
 
         # If no options, can't do anything
         if options is None:
+            return None, None
+
+        # If should be purged, don't pull
+        PurgeObj = BufferPurger()
+        PurgeObj.run_doc = self.run_doc
+        if option_type == 'download' and PurgeObj.check_purge_requirements():
+            self.log.info("Skip download that would be purged")
             return None, None
 
         start = time.time()


### PR DESCRIPTION
* Move purge tasks to end (after processing)
* Count 'rucio-catalog' as a good copy (even though it has different checksum)
* Disable Midway purge exceptions (all will be purged now)
* Create function to check purge rules
    * Use in CopyPull task to ignore these files