### PR TITLE
Correction versioning, tests with fake runs db, drift velocity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,72 @@
+# Temporary python files
+*.py[cod]
+__pycache__
+
+# Data
+*.pklz
+*.xed
+*.root
+*.png
+*.h5
+*.hdf
+*.hdf5
+fax_truth.csv
+
+# C extensions
+*.so
+
+# Packages
+*.eggs
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+htmlcov
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Complexity
+output/*.html
+output/*/index.html
+
+# Sphinx
+docs/_build
+
+#Pycharm or something?
+.idea
+
+.ipynb_checkpoints
+
+Xerawdp_matching
+Bad_ideas
+tpc_kr_150410.eve
+
+debug_event_plots
+debug_output
+analysis/analysis_results
+
+# Numba caches
+*.nbc
+*.nbi

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-# Temporary python files
-*.py[cod]
-__pycache__
-
 # Data
 *.pklz
 *.xed
@@ -70,3 +66,15 @@ analysis/analysis_results
 # Numba caches
 *.nbc
 *.nbi
+
+# Compiled python files
+__pycache__
+*.py[cod]
+
+# Eggs
+.eggs
+*.egg_info
+cax.egg-info
+
+# Pycharm
+.idea

--- a/cax/config.py
+++ b/cax/config.py
@@ -31,6 +31,8 @@ PAX_DEPLOY_DIRS = {
 
 RUCIO_RULE = ''
 
+# URI for the mongo runs database
+RUNDB_URI = 'mongodb://eb:%s@xenon1t-daq.lngs.infn.it:27017,copslx50.fysik.su.se:27017,zenigata.uchicago.edu:27017/run'
 
 
 def mongo_password():
@@ -168,14 +170,13 @@ def get_task_list():
 
     return options
 
-
 def mongo_collection(collection_name='runs_new'):
     # For the event builder to communicate with the gateway, we need to use the DAQ network address
     # Otherwise, use the internet to find the runs database
     if get_hostname().startswith('eb'):
         c = pymongo.MongoClient('mongodb://eb:%s@gw:27017/run' % os.environ.get('MONGO_PASSWORD'))
     else:
-        uri = 'mongodb://eb:%s@xenon1t-daq.lngs.infn.it:27017,copslx50.fysik.su.se:27017,zenigata.uchicago.edu:27017/run'
+        uri = RUNDB_URI
         uri = uri % os.environ.get('MONGO_PASSWORD')
         c = pymongo.MongoClient(uri,
                                 replicaSet='runs',

--- a/cax/main.py
+++ b/cax/main.py
@@ -104,7 +104,7 @@ def main():
         #corrections.AddSlowControlInformation(),  
         data_mover.CopyPush(),  # Upload data through e.g. scp or gridftp to this location where cax running
         #tsm_mover.AddTSMChecksum(), # Add forgotten Checksum for runDB for TSM client.
-	checksum.CompareChecksums(),  # See if local data corrupted
+        checksum.CompareChecksums(),  # See if local data corrupted
         clear.RetryStalledTransfer(),  # If data transferring e.g. 48 hours, probably cax crashed so delete then retry
         clear.RetryBadChecksumTransfer(),  # If bad checksum for local data and can fetch from somewhere else, delete our copy
 

--- a/cax/task.py
+++ b/cax/task.py
@@ -8,7 +8,7 @@ from bson.json_util import dumps
 from cax import config
 
 
-class Task():
+class Task:
     def __init__(self):
         # Grab the Run DB so we can query it
         self.collection = config.mongo_collection()
@@ -38,7 +38,7 @@ class Task():
                                                               projection=('_id'),
                                                               sort=(('start', -1),))]
         except pymongo.errors.CursorNotFound:
-            self.log.warning("Curson not found exception.  Skipping")
+            self.log.warning("Cursor not found exception.  Skipping")
             return
 
         # Iterate over each run

--- a/cax/tasks/corrections.py
+++ b/cax/tasks/corrections.py
@@ -187,7 +187,7 @@ class SetNeuralNetwork(CorrectionBase):
 
 class SetFieldDistortion(CorrectionBase):
 	'''Set the proper field distortion map according to run number'''
-	key = 'processor.simulator.rz_position_distortion_map'
+	key = 'processor.WaveformSimulator.rz_position_distortion_map'
 	collection_name = 'field_distortion'
 
 	def evaluate(self):
@@ -199,7 +199,7 @@ class SetFieldDistortion(CorrectionBase):
 
 class SetLightCollectionEfficiency(CorrectionBase):
 	'''Set the proper LCE map according to run number'''
-	key = 'processor.simulator.s1_light_yield_map'
+	key = 'processor.WaveformSimulator.s1_light_yield_map'
 	collection_name = 'light_collection_efficiency'
 
 	def evaluate(self):
@@ -212,7 +212,7 @@ class SetLightCollectionEfficiency(CorrectionBase):
 class SetS2xyMap(CorrectionBase):
     """Set the proper S2 x, y map according to run number"""
     key = 'processor.WaveformSimulator.s2_light_yield_map'
-    collection_name = 'light_collection_efficiency'
+    collection_name = 's2_xy_map'
     
     def evaluate(self):
         number = self.run_doc['number']

--- a/cax/tasks/corrections.py
+++ b/cax/tasks/corrections.py
@@ -1,16 +1,11 @@
 """Add electron lifetime
 """
 import datetime
-from collections import defaultdict
 
 import numpy as np
-import os
 import sympy
-import time
 import pytz
-import requests
 import hax
-from hax import slow_control
 from pax import configuration, units
 from sympy.parsing.sympy_parser import parse_expr
 

--- a/cax/tasks/corrections.py
+++ b/cax/tasks/corrections.py
@@ -25,7 +25,8 @@ class CorrectionBase(Task):
     And optionally also:
       - version: string indicating correction version. If not given, timestamp-based version will be used.
       - function: sympy expression, passed to sympy.evaluate then stored in the 'function' instance attribute
-
+                  NOTE: if you can't express your correction as a sympy function you can add a custom handling
+                  by overriding the 'evaluate' method with whatever you need
     We keep track of the correction versions in the run doc, in processor.correction_versions.
     This is a subsection of processor, so the correction versions used in processing will be stored in the processor's
     metadata.
@@ -170,3 +171,16 @@ class AddGains(CorrectionBase):
             gains.append(float(gain) * self.correction_units)
 
         return gains
+
+
+class SetNeuralNetwork(CorrectionBase):
+    '''Set the proper neural network file according to run number'''
+    key = "processor.NeuralNet.PosRecNeuralNet.neural_net_file"
+    collection_name = 'neural_network'
+    
+    def evaluate(self):
+        number = self.run_doc['number']
+        for rdef in self.correction_doc['correction']:
+            if number >= rdef['min'] and number < rdef['max']:
+                return rdef['value']
+        return None

--- a/cax/tasks/corrections.py
+++ b/cax/tasks/corrections.py
@@ -209,3 +209,14 @@ class SetLightCollectionEfficiency(CorrectionBase):
 				return rdef['value']
 		return None
 
+class SetS2xyMap(CorrectionBase):
+    """Set the proper S2 x, y map according to run number"""
+    key = 'processor.WaveformSimulator.s2_light_yield_map'
+    collection_name = 'light_collection_efficiency'
+    
+    def evaluate(self):
+        number = self.run_doc['number']
+        for rdef in self.correction_doc['correction']:
+            if number >= rdef['min'] and number < rdef['max']:
+                return rdef['value']
+        return None

--- a/cax/tasks/corrections.py
+++ b/cax/tasks/corrections.py
@@ -184,3 +184,28 @@ class SetNeuralNetwork(CorrectionBase):
             if number >= rdef['min'] and number < rdef['max']:
                 return rdef['value']
         return None
+
+class SetFieldDistortion(CorrectionBase):
+	'''Set the proper field distortion map according to run number'''
+	key = 'processor.simulator.rz_position_distortion_map'
+	collection_name = 'field_distortion'
+
+	def evaluate(self):
+		number = self.run_doc['number']
+		for rdef in self.correction_doc['correction']:
+			if number >= rdef['min'] and number < rdef['max']:
+				return rdef['value']
+		return None
+
+class SetLightCollectionEfficiency(CorrectionBase):
+	'''Set the proper LCE map according to run number'''
+	key = 'processor.simulator.s1_light_yield_map'
+	collection_name = 'light_collection_efficiency'
+
+	def evaluate(self):
+		number = self.run_doc['number']
+		for rdef in self.correction_doc['correction']:
+			if number >= rdef['min'] and number < rdef['max']:
+				return rdef['value']
+		return None
+

--- a/examples/Drift velocity to runs db.ipynb
+++ b/examples/Drift velocity to runs db.ipynb
@@ -1,0 +1,386 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import pymongo\n",
+    "import sympy\n",
+    "from sympy.parsing.sympy_parser import parse_expr\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Maybe you have to change mongo url to something else if you're non the DAQ network? See cax.config.\n",
+    "client = pymongo.MongoClient('mongodb://eb:%s@xenon1t-daq.lngs.infn.it:27017/run' % os.environ['MONGO_PASSWORD'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Check format from purity collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "12"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "purity_coll = client['run']['purity']\n",
+    "purity_coll.count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "d = purity_coll.find_one()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2017-02-15 10:36:32.554000 571.536805205327/(1 + 2.85936983046934e+138*exp(-2.15875349579075e-7*t))\n",
+      "2017-02-09 11:34:52.728000 726.439274517567/(1 + 2.0260694424652e+84*exp(-1.3126159999747e-7*t))\n",
+      "2017-02-08 12:40:54.433000 726.439274517567/(1 + 2.0260694424652e+84*exp(-1.3126159999747e-7*t))\n",
+      "2017-01-12 16:57:05.376000 664.009433008032/(1 + 9.20429790014259e+57*exp(-9.05409401619292e-8*t))\n",
+      "2016-12-07 15:24:34.858000 3293.34246828997/(1 + 3.61800535059737e+15*exp(-2.29229212119497e-8*t))\n",
+      "2016-10-19 10:10:51.244000 451.092742358951/(1 + 2.19032421518171e+1011*exp(-1.57823407887515e-6*t))\n",
+      "2016-09-19 05:55:53.102000 317.29661042819/(1 + 1.05633549046867e+880*exp(-1.37598762559539e-6*t))\n",
+      "2016-09-19 05:55:53.102000 317.29661042819/(1 + 1.05633549046867e+880*exp(-1.37598762559539e-6*t))\n",
+      "2016-07-26 10:23:33.859000 323.085761530256/(1 + 2.60535248526874e+1028*exp(-1.61211864700664e-6*t))\n",
+      "2016-07-26 10:23:33.859000 323.085761530256/(1 + 2.60535248526874e+1028*exp(-1.61211864700664e-6*t))\n",
+      "2016-07-14 12:11:37.671000 299.124801429751/(1 + 1.22494241740575e+1063*exp(-1.66807062881465e-6*t))\n",
+      "2016-06-15 08:26:08.173000 9.93103054982358e-672*exp(1.05654787355925e-6*t)\n"
+     ]
+    }
+   ],
+   "source": [
+    "for d in purity_coll.find(sort=(('calculation_time', -1), )):\n",
+    "    print(str(d['calculation_time']), parse_expr(d['function']))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Try to add drift velocity correction function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 132,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "data = np.array([\n",
+    "    4,  0.9948,       # Julien\n",
+    "    5,  1.1224,       # Julien\n",
+    "    6,  1.2137,       # Julien\n",
+    "    7,  1.2833,       # Julien\n",
+    "    8,  1.3323,       # Julien\n",
+    "    9,  1.371,        # Jelle\n",
+    "    12, 1.4401,       # Jelle & Julien (same value, well Julien had 1.4402 and I had 1.440...)\n",
+    "    13, 1.456,\n",
+    "    15, 1.482\n",
+    "])\n",
+    "\n",
+    "cathode_kv, vdrift_kmpers = data.reshape(-1, 2).T"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 133,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 149,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.text.Text at 0x7fd3fcc59e80>"
+      ]
+     },
+     "execution_count": 149,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEKCAYAAAD9xUlFAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3Xd8FHX++PHXOwUCCSSUhN4VCCXEAIqCAqcCKhYsZy/o\nHaJycHh3lu95Gj3vfudZEEVF9BBFxXaKDRQVQlGQGnoPoUMSIIGEhJR9//7YzV4IKQtkS5L38/HY\nBzszn5l5Z3aZ98585vP5iKpijDHGAAT5OwBjjDGBw5KCMcYYN0sKxhhj3CwpGGOMcbOkYIwxxs2S\ngjHGGDdLCsYYY9wsKRhjjHGzpGCMMcYtxN8BnK6mTZtq+/bt/R2GMcZUKytWrMhQ1ejKylW7pNC+\nfXuWL1/u7zCMMaZaEZGdnpSz20fGGGPcLCkYY4xxs6RgjDHGzZKCMcYYN0sKxhhj3CwpGGOMcbOk\nYIwxxs2SgjHGVANr9mSSfaLQ6/uxpGCMMQHu69X7uHHyYv7frI1e31e1a9FsjDG1haryetJ2nv9+\nM33bN+JPQ7p4fZ+WFIwxJgCdKCzibzPX8cnyPVwb35J/3xhH3ZBgr+/XkoIxxgSY/Vm5PPD+SpJ3\nZzL20nMZf9m5iIhP9m1JwRhjAsiSlEOM+XAluflFTL4jgWE9Wvh0/16raBaRqSKSJiLrKigzSESS\nRWS9iMz3VizGGBPoihzKpLlbuf3tX2lYL5Qvx/T3eUIA714pTAMmAe+VtVBEooDXgWGquktEYrwY\nizHGBKwDWXn88eNVLEk5zNW9WvLPET1oEBbql1i8lhRUdYGItK+gyG3A56q6y1U+zVuxGGNMoPpm\nzT7+NnMdJwodPH9jHDf2bu2z+oOy+LNOoTMQKiJJQANgoqqWd1UxChgF0LZtW58FaIwx3pKRfYIn\nv1zHrLUH6NU6kpdujqdTdIS/w/JrUggBegOXAvWAxSKyRFW3lC6oqlOAKQB9+vRRn0ZpjDFVSFX5\nYtVenv12I9l5hTwyrAujLu5ISHBgtCX2Z1LYAxxS1RwgR0QWAL2AU5KCMcbUBNvSsnli5lqWpBym\nV5so/n1DHF2aN/B3WCfxZ1L4EpgkIiFAHeACYIIf4zHGGK/Iyi3gtXnbeOfnHdQLDeYfI3pwa9+2\nBAX5r+6gPF5LCiIyAxgENBWRPcBTQCiAqk5W1Y0i8h2wBnAAb6tquY+vGmNMdVNQ5GDG0l1M+GEL\nmbkF3NS7NY8M60rTiLr+Dq1c3nz66FYPyjwPPO+tGIwxxh+KHMpXq/fy8o9b2XnoOBd2bMITw2Pp\n3jLS36FVylo0G2NMFSlyKN+u3c+rP21la1o2sS0a8p+7+/CbrjF+fcz0dFhSMMaYs3SisIgvVu5l\n8vztpB46zjkxEbx2WwJX9GgekPUGFbGkYIwxZygj+wQfLNnF9CU7ycg+Qc9WkUy+ozdDujWrdsmg\nmCUFY4w5DarKip1H+PDXXXyzZj/5RQ4Gd4nm3gEdGHBO02pzm6g8lhSMMcYD6cdO8GXyXj5Zvpst\nB7OJqBvCzX3bcE//9gHRErmqWFIwxphyHM8v5MeNacxctZf5W9Ipcii9Wkfy3A09ubpXS+rXqXmn\n0Jr3FxljzFnIOVHI/C3pfLt2Pz9tPEhegYNmDevy+4s7cn1CKzo3C6wWyFXNkoIxptY7kJVH0uY0\nfthwkIXbMsgvdNAkvA439m7NVT1bcn6HxgRX04rj02VJwRhT65woLGJF6hEWbssgaXM6G/cfBaBV\nVD1uv6AtQ7s3p0+7RgHTSZ0vWVIwxtR4BUUO1uzJYknKIZakHGJZ6mHyChyEBAm92zXi0WFdGdw1\nmi7NGlT7p4fOliUFY0yNk3W8gFW7j7Bi5xGWpx4heXcmuQVFAHRuFsEtfdsy4Jym9OvUhIi6dhos\nyY6GMaZayysoYuP+o6zdm0Xy7kySd2eSkp4DQJBAt5YNublvGy7o0JjzOzSmSQB3RhcILCkYY3xO\nVU+6TVN6ujxZxwvYeOAoG/YdZf2+o6zfl8W2tGwKHc6xt5pG1CG+TRQ3JLQmvk0UvdpE2ZXAabKj\nZYzxqcTERDIzM5kwYQIigqoyfvx4oqKiSExMBJy//lPSc9hy8BibDhxj84GjbD5wjH1Zee7tRDeo\nS/eWDbk0Noa41lHEtY6kecOwWl8ncLYsKRhjfEZVyczMZOLEiQD847nneeixZ/jsh9VcdMX13D99\nOVsPZpN6KAfXj39Cg4VO0RH07dCY2BYNna/mDYhpGObHv6TmEtXqNeRxnz59dPny5f4OwxjjIVUl\n/dgJtqVnk5Kew/a0bL5duJx92Q5CImPc5YKDhHZN6nNuTASdmzVwvzo0DadOSO17NLSqicgKVe1T\nWTm7UjDGVInc/CJ2ZOSQkuE8+aekZ5OSkUNKeg7ZJwrd5erXCaZjm47s+OErsld/T8HhPaxMmkWH\nphF28g8AlhSMqaXOpLJXVTlwNI/taf87+W93XQHszcw9qWyrqHp0jA7nhoRWdIqJoGPTCDrFhNOs\nQV0efvhhvv1morvsG/96kgkTbIj2QGBJwZhaqLLK3vxCBzsP5bAtLZvt6dmuf52//nPyi9zbCa8T\nTMfoCPq0b8TN0W3oGB1Ox6YRdGgaTr06wafst3g/EydOZNy4cUyYMME9DbjjMf5jScGYauxMf+0X\nV/YWEcToR57iyRfeYO7KQ3S9II6FLyax89Bx92Oe8L9f/Tf1aUOn6HA6RUfQMTqCZg3rntZJXESI\niopyJwQRcV8hREVFWUIIAFbRbEw15cmjncWKHMrOQzlsPuB6xPPgMRat2c4xwpAg5y96UQcdYhpw\nbkwE5xS/ohvQMTqc8Cp+1v9M2ymYM2cVzcbUYKUf7Sx5G+bBcQ+zdMchNu4/xsb9R9m4/yibDx4j\nr8ABgAi0bxJO/54d+fitiRRk7KIgfSdH920jLNQ3p4TSCcASQuCwKwVjqilV5cHxjzDty5+o06wT\ndZqfQ0znBHKC6rvLNKofSmyLhnRt3pCuLRoQ27wh58REEBYadNK9fOCkWzqm5rErBWNqmJwThazd\nm8Xq3Zms2ZPF6j2Z7AkbRLObBwFQcGQ/F8d1pEfLhnRr2ZBuLSLLvOdvlb2mIpYUjAlAqsr29BxW\n7jrCql1HWLUrky0Hj7lb+bZuVI+41pFEpq1m7mfTyD+4HceJHMLqjeOhSk7qVtlrKmJJwZgAkF/o\nYO3eTJbuOMLy1MOs2HWEzOMFADQMC+G8to0Y2r058W2j6NU6ikb1Qxk/fjyz3L/2k0/r135iYuJJ\nlbvFicESgrGkYIwf5BUUkbw70z3oy6pdmZwodFYEd4oOZ0i3ZvRp15iEdo3o2DScoDKGgjzbX/tW\n2WvK4rWKZhGZCgwH0lS1RwXl+gKLgVtU9bPKtmsVzaY6KnIo6/ZmsWhbBr9sz2BZ6hHyCx2IQLcW\nDbmgQxPO79CYvu0bnVZ///Zop/FUIFQ0TwMmAe+VV0BEgoHngDlejMMYv9iflcuCLeks2JLBom0Z\nZOU6bwd1bd6AOy5ox0WdmtC3Q2Mi64We8T7s176pal5LCqq6QETaV1LsD8B/gb7eisMYXylyKCt3\nHWHupjTmbUpj04FjADRrWJfLuzXj4nOb0v+cpjS1kb9MAPNbnYKItAJGAIOxpGCqqeP5hSzYks6c\nDQeZtymNI8cLCAkS+rRvxONXdGVQlxg6N4uwX/Cm2vA4KYhIOJCnqkWVFvbMy8Cjquqo7D+MiIwC\nRgG0bdu2inZvzJk5llfAjxsPMnvtARZsTSevwEFkvVB+0zWGS2NjuKRzNA3DzvyWkDH+VG5SEJEg\n4Bbgdpy/5E8AdUUkA/gWeFNVt53FvvsAH7kSQlPgShEpVNWZpQuq6hRgCjgrms9in8aUqbIK25wT\nhfy48SBfr97Pgq3p5Bc6aN4wjJv7tGFo9+ac36ExIcE2FoCp/iq6UpgH/Ag8DqxTVQeAiDTGecvn\nORH5QlXfP5Mdq2qH4vciMg34pqyEYIy3ldexXMPIRgy6dTQzV+3jhw0HyS0ookVkGHdc0I6r4ppz\nXptGZT4qakx1VlFSuExVC0rPVNXDOCuH/ysi5V4ji8gMYBDQVET2AE8Boa5tTD6boI2pKmV1LHfv\nw3/jy7U5RPe5hPemLSeqfijXJ7Ti2vhW9GlnicDUbJW2UxCRfsB6VT3mmm4IxKrqrz6I7xTWTsFU\nNVVlzPg/817SeiJ6DaVui86IOhjaowU39G7DwM7RNkykqfaqsp3CG0BCiensMuYZUy1t2HeU6Ut2\nMq/h5TQZ9hvy01M5/OObpCZ9SmN7dNTUQp4kBdESlxOup4WsewxTbRUUOfhu3QGm/ZLKip1HqBsS\nRLO83fz64Yvk798CwDNPPGp9AZlayZNr4hQRGSsioa7XOCDF24EZU9WyjhfwRtJ2Lvn3PP4wYxUZ\n2Sd44qpYLs3+iYUv3s8Dv70Ch8PBuHHjmDhxIuPHj6e6jTdizNny5Bf/aOAV4AlAgZ9wtRkwJpCU\n91jp/qxc/rNwBzOW7iInv4iLOjXh79f2YHDXGIKDhMSfIqwbaWNcbOQ1UyOU9VjpqIf/j9T6XUgl\nBofC1XEt+P0lHeneMvKU9a1jOVPTVVlFs4h0xlmx3ExVe4hIHHCNqj5bBXEac9ZKP1Y69q/Pcve/\nZ7Ar9EKCC+H2C9sy6pKOtGlcv9xtWMdyxjh5cvvoLeAvwJsAqrpGRD4ELCmYgFB8y+c4YUzffJwv\nnp+LOhpzruzhw7+NpFlkPX+HaEy14UlSqK+qS0v9cir0UjzGnLYjOflMmreNpPCBRHQ/wbGV35K1\n5BN2Hjtsv/iNOU2eJIUMEemEs5IZEbkR2O/VqIzxQF5BEdN+SeW1edvIOVFI64K9/DLlCYqOpQMw\nfvx4e6zUmNPkySOpD+G8ddRVRPYCfwQe8GpUxlRAVflu3QEunzCff83eRN92jRiU9wsLX7yfMffe\nZo+VGnMWKr1SUNUU4DJX19lBxd1dGOMPWw8eI/Hr9fy87RBdmjXgg99dQP9zmpKYOMseKzWmCnjS\n99E44B3gGM5K5wTgMVX1yxCa9khq7ZSbX8Src7cyZUEK4XVDePjyztx+QduTuqu2x0qNKV9V9n10\nr6pOFJGhQBPgTmA6Nq6y8YKyTuwLtmbwxMy17D6cyw0Jrfm/K7uWObi9PVZqzNnzqO8j179XAu+p\n6nqx/23GC0o3QMs8ns81T05jV0grOkWHM+P3/biwUxN/h2lMjeZJUlghInOADsDjItIAcHg3LFPb\nlG6ANnzUY4x59xdyg5rTpTCFr8Y+QFio9cNojLdVNBxnqGuQnfuAeCBFVY+LSBNgpK8CNLVDceVw\nIcFM35TPzPdWkJ++jyGRB3nnpWfsVpAxPlLRT6/FrhHTvgO+U9VMAFU9BBzyRXCmdlm1O5O1LYcT\nUTebrCWfkrnoA94pyLeEYIwPldtOwVVL/UfX5MsiskxEJojIEBGx0UdMlXE4lMnzt3PT5MWkHTrE\nwQ8fJ3P+u1BUaO0MjPGxChuvqWqqqk5W1euAi4CvgcuAhSLyrS8CNDXboewTjJy2jH/N3kSzgv1s\nfvluRt9wmTVAM8ZPPK65c9UvzHW9EJFW3grK1A4rdx3hwfdXcvh4Pv8Y0YMts5Zx/gO/twZoxviR\nJ43XhgN/B9oDwTgfUVVVbej16MpgjdeqP1Xlw6W7SPxqPc0jw5h8R2/3GAfWAM0Y76jKxmsvA9cD\na9Wu4c1Zyi908LeZ6/h4+W4Gdo5m4i3xRNWv415uDdCM8S9PksJuYJ0lBHO2DufkM3r6CpamHuah\nwZ14+PIuBAfZSd+YQOJJUngEmCUi84ETxTNV9SWvRWVqnG1px7h32nIOHM1j4i3xXBtvVVLGBCJP\nksI/gGwgDKhTSVljTqkHWLw9g1HTV1A3JJiPRvUjoW0jP0ZnjKmIJ0mhpar28HokpkYo3X/RN2v2\nMfaDFTQIOsHMcVfSulH54yQbY/zPk6QwS0SG+KurbFN9lO6/KP6mcSR+tZ68vZsY1vQgraJu8HOE\nxpjKeJIUHgD+LCIngAI8fCRVRKYCw4G0sq40ROR24FHX9o4BD6jq6tOM3wSQ4rYFCkxbdpCosA0c\n37qEm9se55UJL9qTRMZUA56MvNag9DwPu86eBkwC3itn+Q5goKoeEZErgCnABR5s1wS45kPuJyos\nhey1P3Fo9kReKSq0hGBMNVHpGM0i8kyp6SDg/crWU9UFwOEKlv+iqkdck0uA1pVt0wQ2h0N58sv1\nvLkghWMrv+HQrJdBHdZNhTHVSKVJAWgjIo8DuDrC+wLYWsVx3AfMruJtGh9SVf725TqmL9lJ1q//\n5Y5udXE4iqz/ImOqGY+G4wQ+cCWGwcAsVX25qgIQkcE4k8KACsqMAkYBtG3btqp2baqIqvLUV+v5\n4Ndd9AzeT8deDXnZ+i8yploqt+8jEUkoMRkKvAn8DPwHQFVXVrpxkfbAN+U90ioicTivPK5Q1S2e\nBGx9HwUWVeWZbzbwzs+pjLqkI49f0RXA+i8yJsBURd9HL5aaPgJ0c81X4DdnHh6ISFvgc+BOTxOC\nCTwvzNnMOz+ncm//Djx+RdcyT/6WEIypPspNCqo6+Gw2LCIzgEFAU9cIbk/hvOJAVScDTwJNgNdd\nJ41CT7KYCRxvL0zhtXnbufX8NvxteKyd/I2pASoao/kO4IPyOsITkU5AC1VdVNZyVb21oh2r6u+A\n351GrCaAfLZiD89+u5ErejTn2et6WkIwpoao6PZREyBZRFYAK4B0nP0fnQMMBDKAx7weoQk4czcd\n5NH/rmHAOU15+ZZ46+nUmBqkottHE0VkEs66g/5AHJALbMRZD7DLNyGaQLJ2TxYPfbCK2BYNePPO\n3tQNCfZ3SMaYKlThI6mqWgT84HqZWm5vZi73vruMxuF1mHp3X8LrejyaqzGmmrD/1cYjR/MKGPnO\nUvIKivjgdxcQ0zDM3yEZY7zAkxbNppYrcihjZ6wiJT2HyXf0pnOzU7rDMsbUEJ70fWQ3jWuhkg+d\n/fv7TSRtTufpa7vT/5ymfozKGONtnlwpbBWR50Wkm9ejMQEhMTHR3VfRl8l7eXN+Cu0Ld7N19jv+\nDs0Y42We1Cn0Am4B3nb1kDoV+EhVj3o1MuMXJQfKyZQGLA6/iCaOI8yf8Afi//CQdVlhTA3nyXgK\nx4C3gLdEZCDwITBBRD4D/q6q27wco/Gh4k7s8gnhq9z2cOIA294dz7g/POQeYtMYU3N5VKcgIteI\nyBfAyzj7PuoIfA3M8nJ8xg9UIS/+ZoIbNCH9y+dwHM+yhGBMLeFRnQJwLfC8qp6nqi+p6kFV/Qz4\nzrvhGX94c8F25m5K48jc/5C/bzOAjYdgTC3hSVK4S1XvU9VfimeISH8AVR3rtciMXyxJOcS/Z28k\nZ+MCRl7cCYfDYQPlGFOLeFLR/AqQUGreq2XMM9Vc5vF8/vhRMg2C8rmyQ6ENlGNMLVRRL6kXAhcB\n0SLycIlFDQFru1DDqCqP/Xcth3JO8PlDl9Gj1fXuBFCcGCwhGFPzVXSlUAeIcJUp2YT1KHCjN4My\nvvfRst18t/4A/3dlV3q2jjxluSUEY2qHinpJnQ/MF5FpqrrThzEZH9uWls3TX69nwDlN+d2Ajv4O\nxxjjRxXdPnpZVf8ITBKRU2oXVfUar0ZmfKKwyMHDnyRTLzSYF3/biyAbG8GYWq2i20fTXf++4ItA\njH+8kbSdNXuyeO22BJpZz6fG1HoV3T5a4Xq7HMhVVQe4O8ir64PYjJdt2HeUV+ZuZXhcC66Ka+Hv\ncIwxAcCTdgo/AfVLTNcDfvROOMZX8gsd/OnT1UTWq8Pfr+3h73CMMQHCk6QQpqrZxROu9/UrKG+q\ngUnztrFx/1H+OaIHjcLr+DscY0yA8CQp5IiIu6GaiPTGOVazqaa2HDzGG0nbuC6+JUO6N/d3OMaY\nAOJJi+Y/Ap+KyD5AgObAzV6NyniNw6E8/vlaIuqG8LfhNkSGMeZknnSdvUxEugJdXLM2q2qBd8My\n3vLB0l2s2HmEF27qRZMIe17AGHOySpOCiIQCDwCXuGYliciblhiqnwNZefx79iYu6tSEGxJa+Tsc\nY0wA8uT20RtAKPC6a/pO17zfeSso4x1Pf72e/CIH/xzR07qtMMaUyZOk0FdVe5WYnisiq70VkPGO\nBVvSmb3uAH+6vDPtm4b7OxxjTIDy5OmjIhHpVDwhIh2BIu+FZKpafqGDxK/X065JfX5/ifVtZIwp\nnydJ4S/APBFJEpH5wFzgT5WtJCJTRSRNRNaVs1xE5BUR2SYia0o+9mrOXsnBcN75eQcp6TkkXt2d\nsFDr9dwYU75Kk4Kq/gScC4wF/gB0UdV5Hmx7GjCsguVXuLZ7LjAKZz2FqQKJiYnuUdIOZOXxyk9b\naV6UzvyPXq98ZWNMrVZRL6nXl7PoHBFBVT+vaMOqukBE2ldQ5FrgPXX+pF0iIlEi0kJV91cWtCmf\nqpKZmcnEiROd0xfcTe6JfLa89Rj97rkFVbVKZmNMuSqqaL66gmUKVJgUPNAK2F1ieo9r3ilJQURG\n4byaoG3btme525qt5PCZb3wymxZhl5O5+FMeuucWGz3NGFOpinpJHenLQCqiqlOAKQB9+vSxkeMr\nISK89NJLfJTRisLswxxd8hkT5h+3hGCMqVSldQoi0kxE/iMis13T3UTkvirY916gTYnp1q555iyp\nKjf/+V+Ete5G1sL30YI8dx2DMcZUxJOnj6YB3wMtXdNbcPaHdLa+Au5yPYXUD8iy+oSzp6qMHf8w\nvxxvRkPHMY6snM24ceOYOHGiJQZjTKU8abzWVFU/EZHHAVS1UEQqbacgIjOAQUBTEdkDPIWzZTSq\nOhmYBVwJbAOOAwFzu6o6ExH2R3QmNKw5r47sS0hwkLuOISoqym4hGWMq5ElSyBGRJjgrlyn+VV/Z\nSqp6ayXLFXjIkyCN57KOF7AlpCMDOzZiYJcY4H+Vz5YQjDGV8SQp/AnnrZ5OIvIzEA3c6NWozBl7\nc8F2juYV8uiwrifNt4RgjPGEJ11nrxCRgTi7zhas6+yAlXYsj3d+TuWaXi3p1rKhv8MxxlRDnjx9\ntAZ4BMhT1XWWEALX6/O2k1/kYPzlnf0dijGmmvLk6aOrgULgExFZJiJ/FhFrQRZgdh8+zge/7uS3\nfVrTwXpBNcacIU/6Ptqpqv9W1d7AbUAcsMPrkZnTMvGnrYgIYy8919+hGGOqMU8qmhGRdjjHZb4Z\nZ7fZj3gzKHN6UtKz+XzlHkb270CLyHr+DscYU415MhznrzjbF3wC3KSqKV6PypyW1+Ztp05IEKMH\ndqq8sDHGVMCTK4W7VHWz1yMxZ2TnoRxmJu/lnovaE92grr/DMcZUc57UKVhCCGCvzdtGSJBwv42o\nZoypAp48fWQC1O7Dx/l85V5uPb8tMQ3D/B2OMaYG8KSdwin3JMqaZ3zv9aRtBIlYXYIxpsp4cqWw\n2MN5xof2Zeby2Yo93Ny3Dc0j7SrBGFM1KhqOsznOkdDqich5OLu4AGgI1PdBbKYC/1m0A4fC/QOt\nLsEYU3UqevpoKHAPzsFvXuR/SeEo8H/eDctUJPN4PjOW7uKaXi1p3cjyszGm6lSUFKJUdbCIPKGq\nz/osIlOp6Yt3cjy/yK4SjDFVrqI6heJBb673RSDGM3kFRUz7JZXBXaLp2tx6QjXGVK2KrhQ2ishW\noKWrp9RignOMnDjvhmbK8uny3RzKyed+e+LIGOMF5SYFVb3VVdn8PXCN70Iy5SkscvDWwh3Et4ni\ngg6N/R2OMaYGqrCbC1U9APTyUSymEj9sOMiuw8f5vyu72khqxhivqOiR1E9U9bcishbX+MzFi7Db\nR34x9ecdtGlcj8u7Nfd3KMaYGqqiK4Vxrn+H+yIQU7E1ezJZlnqEvw3vRnCQXSUYY7yjojqF/SIS\nDExT1cE+jMmU4Z2fU4moG8Jv+7T2dyjGmBqswm4uVLUIcIhIpI/iMWVIO5rHN2v2cVOf1jQIC/V3\nOMaYGsyT8RSygbUi8gOQUzxTVcd6LSpzkveX7KTQodxzUXt/h2KMqeE8SQqfu17GD/IKinj/111c\nFtuMdk3C/R2OMaaGqzQpqOq7IhLtep/u/ZBMSd+s2c/hnHxG2lWCMcYHyq1TEKdEEckANgNbRCRd\nRJ70XXhm+pKdnBMTwYWdmvg7FGNMLVBRRfN4oD/QV1Ubq2oj4AKgv4iM92TjIjJMRDaLyDYReayM\n5ZEi8rWIrBaR9SIysqzt1Fbr9maxencmt1/Q1hqrGWN8oqKkcCdwq6ruKJ6hqinAHcBdlW3Y9Tjr\na8AVQDfgVhHpVqrYQ8AGVe0FDAJeFJE6p/UX1GDvL9lJvdBgrk+wx1CNMb5RUVIIVdWM0jNd9Qqe\nPBd5PrBNVVNUNR/4CLi29OaABuL8GRwBHAYKPYq8hsvKLWBm8l6ujW9JZD17DNUY4xsVJYX8M1xW\nrBWwu8T0Hte8kiYBscA+YC0wTlUdpTckIqNEZLmILE9Prx113Z+v3ENegYM7+rXzdyjGmFqkoqTQ\nS0SOlvE6BvSsov0PBZKBlkA8MElEThkkQFWnqGofVe0THR1dRbsOXKrK+0t20qtNFD1aWbtBY4zv\nlJsUVDVYVRuW8Wqgqp7cz9gLtCkx3do1r6SRwOfqtA3YAXQ93T+iplmScpjt6TncaVcJxhgfq7Cb\ni7O0DDhXRDq4Ko9vAb4qVWYXcCmAiDQDugApXoypWvh42S4ahIVwVc8W/g7FGFPLeNKi+YyoaqGI\njME5SE8wMFVV14vIaNfyycDfgWmu7rkFeLSsyu3aJCu3gNnrDnBTn9bUqxPs73CMMbWM15ICgKrO\nAmaVmje5xPt9wBBvxlDdfJW8lxOFDm7u09bfoRhjaiFv3j4yZ+Dj5buJbdGQHq1OqW83xhivs6QQ\nQNbvy2Ld3qPc0reNtWA2xviFJYUA8smy3dQJCeK6+NLNOYwxxjcsKQSIvIIiZibvY1j35kTWtxbM\nxhj/sKQQIOZsOEhWbgE3921TeWFjjPESSwoB4vOVe2gVVY8LO1oX2cYY/7GkEADSjuWxcGsG18a3\nJCjIKphmXF3jAAAZVUlEQVSNMf5jSSEAfJW8jyKHcn2CVTAbY/zLkkIA+GLVXuJaR3JOTAN/h2KM\nqeUsKfjZ5gPHWL/vKCPOs6sEY4z/WVLws89X7SEkSLi6V0t/h2KMMd7t+8hUrMihfLlqHwM7R9M0\noq6/wzFVoKCggD179pCXl+fvUEwtFRYWRuvWrQkNPbP2TpYU/Gjx9kMcOJrHE8Nj/R2KqSJ79uyh\nQYMGtG/f3roqMT6nqhw6dIg9e/bQoUOHM9qG3T7yo69W7yWibgiXxTbzdyimiuTl5dGkSRNLCMYv\nRIQmTZqc1ZWqJQU/OVFYxHfrDjCkezPCQm3chJrEEoLxp7P9/llS8JMFWzI4mldoFcymyrVv356e\nPXsSHx9Pnz593POnTZvGvn37TiqXkXF6Y1oNGjSI5cuXV1msvnTPPffw2Wef+WXfV155JZmZmRWW\nKe/z+PTTT4mNjWXw4MEsX76csWPHApCUlMQvv/xS5bFanYKffL16H1H1QxlwTlN/h2JqoHnz5tG0\n6cnfrWnTptGjRw9atvT/D5HCwkJCQmrP6WfWrFmVFyrHf/7zH9566y0GDBgA4E70SUlJREREcNFF\nF1VJjMXsSsEPjucX8sOGg1zRowWhwfYRGO/77LPPWL58Obfffjvx8fHk5uYC8Oqrr5KQkEDPnj3Z\ntGnTKevl5uZyyy23EBsby4gRI9zrAcyZM4cLL7yQhIQEbrrpJrKzswHnCbBr16707t2bsWPHMnz4\ncAASExO588476d+/P3feeSdFRUX85S9/oW/fvsTFxfHmm2+6t/3888+75z/11FNl/k0RERGMHz+e\n7t27c+mll5Keng5AcnIy/fr1Iy4ujhEjRnDkyJGT1ps7dy7XXXede/qHH35gxIgR7m3+9a9/pVev\nXvTr14+DBw8CkJqaym9+8xvi4uK49NJL2bVrF+C8+njggQfo168fHTt2JCkpiXvvvZfY2Fjuuece\n9z5KXgVcd9119O7dm+7duzNlypQKP7dnnnmGRYsWcd999/GXv/yFpKQkhg8fTmpqKpMnT2bChAnE\nx8ezcOHCCrdzOmpPqg4gczelkVtQxNW9Wvg7FONFT3+9ng37jlbpNru1bMhTV3evsIyIcNlllxEc\nHMz999/PqFGjuPHGG5k0aRIvvPDCSbeUmjZtysqVK3n99dd54YUXePvtt0/a1htvvEH9+vXZuHEj\na9asISEhAYCMjAyeffZZfvzxR8LDw3nuued46aWXeOSRR7j//vtZsGABHTp04NZbbz1pexs2bGDR\nokXUq1ePKVOmEBkZybJlyzhx4gT9+/dnyJAhbN26la1bt7J06VJUlWuuuYYFCxZwySWXnLStnJwc\n+vTpw4QJE3jmmWd4+umnmTRpEnfddRevvvoqAwcO5Mknn+Tpp5/m5Zdfdq83ePBgHnzwQdLT04mO\njuadd97h3nvvdW+zX79+/OMf/+CRRx7hrbfe4oknnuAPf/gDd999N3fffTdTp05l7NixzJw5E4Aj\nR46wePFivvrqK6655hp+/vln3n77bfr27UtycjLx8fEnxT116lQaN25Mbm4uffv25YYbbqBJk7I7\nwnzyySeZO3eu+3NLSkoCnElm9OjRRERE8Oc//7nC78Ppsp+pfvD16n1EN6jLBR2sR1RT9RYtWkRy\ncjKzZ8/mtddeY8GCBeWWvf766wHo3bs3qamppyxfsGABd9xxBwBxcXHExcUBsGTJEjZs2ED//v2J\nj4/n3XffZefOnWzatImOHTu6H4csnRSuueYa6tWrBzivNN577z3i4+O54IILOHToEFu3bmXOnDnM\nmTOH8847j4SEBDZt2sTWrVtPiS0oKIibb74ZgDvuuINFixaRlZVFZmYmAwcOBODuu+8+5e8XEe68\n807ef/99MjMzWbx4MVdccQUAderUcV/ZlDwmixcv5rbbbgPgzjvvZNGiRe7tXX311YgIPXv2pFmz\nZvTs2ZOgoCC6d+9e5jF95ZVX3Fciu3fvLvNv8ye7UvCxo3kFzNuczm3ntyXYekSt0Sr7Re8trVo5\nu0yJiYlhxIgRLF269JRf2cXq1nU2mgwODqawsNDjfagql19+OTNmzDhpfnJycoXrhYeHn7SNV199\nlaFDh55U5vvvv+fxxx/n/vvv9zgeOL2nbkaOHMnVV19NWFgYN910k7t+IzQ01L0dT49J8TEMCgpy\nvy+eLr1+UlISP/74I4sXL6Z+/foMGjQo4Bo62pWCj/2w/iD5hQ576sh4RU5ODseOHXO/nzNnDj16\n9ACgQYMG7mWeuuSSS/jwww8BWLduHWvWrAGgX79+/Pzzz2zbts29ry1bttClSxdSUlLcv5A//vjj\ncrc9dOhQ3njjDQoKCgDYsmULOTk5DB06lKlTp7rrKPbu3UtaWtop6zscDvfTRB9++CEDBgwgMjKS\nRo0aue+xT58+3X3VUFLLli1p2bIlzz77LCNHjqz0OFx00UV89NFHAHzwwQdcfPHFla5TlqysLBo1\nakT9+vXZtGkTS5YsOaPtwJl9np6wKwUfm7V2Py0jw0hoG+XvUEwNdPDgQXelaWFhIbfddhvDhg0D\nnJWio0ePpl69eixevNij7T3wwAOMHDmS2NhYYmNj6d27NwDR0dFMmzaNW2+9lRMnTgDw7LPP0rlz\nZ15//XWGDRtGeHg4ffv2LXfbv/vd70hNTSUhIQFVJTo6mpkzZzJkyBA2btzIhRdeCDgrf99//31i\nYmJOWj88PJylS5fy7LPPEhMT405A7777LqNHj+b48eN07NiRd955p8z933777aSnpxMbW3mPAq++\n+iojR47k+eefd9dDnIlhw4YxefJkYmNj6dKlC/369Tuj7YDzttWNN97Il19+yauvvnrGiao0UdUq\n2ZCv9OnTR6vrc9LH8gro/fcfuaNfO568upu/wzFesHHjRo9OMjVZdnY2ERERqCoPPfQQ5557LuPH\nj6/y/URERLivJs7EmDFjOO+887jvvvuqMKrAUNb3UERWqGqfclZxs9tHPjR3Uxr5RQ6u6Nnc36EY\n4zVvvfUW8fHxdO/enaysrNOuG/CF3r17s2bNGncluvkfu33kQ9+tO0B0g7r0btvI36EY4zXjx4/3\nypVBaWdzlbBixYoqjKRmsSsFH8nNLyJpczpDuzezcZiNMQHLq0lBRIaJyGYR2SYij5VTZpCIJIvI\nehGZ7814/Gn+FmeDtSt6WIM1Y0zg8trtIxEJBl4DLgf2AMtE5CtV3VCiTBTwOjBMVXeJSEzZW6v+\nZq87QKP6oVzQobG/QzHGmHJ580rhfGCbqqaoaj7wEXBtqTK3AZ+r6i4AVT31YeQa4ERhEXM3pnF5\nt2aEWF9HxpgA5s0zVCtgd4npPa55JXUGGolIkoisEJG7vBiP3/y8LYNjJwrt1pHxuuDgYPeTP716\n9eLFF1/E4XBUuE5qaqq7gVpV86TL6NJdehv/8vfP1hCgN3AVMBT4m4h0Ll1IREaJyHIRWV7cE2J1\n8t26AzSoG8JF51hfR+ZkpdsJnW27oXr16pGcnMz69ev54YcfmD17Nk8//XSF63gzKcyaNYuoqIob\nalpSCCzeTAp7gTYlplu75pW0B/heVXNUNQNYAPQqvSFVnaKqfVS1T3R0tNcC9oYih/LTxjQGdY2h\nboiNsGb+JzExkfHjx7sTgaoyfvx4EhMTq2T7MTExTJkyhUmTJqGqpKamcvHFF5OQkEBCQoJ7gJbH\nHnuMhQsXEh8fz4QJE8otl5SUxCWXXMJVV11Fly5dGD16tPsqZMaMGfTs2ZMePXrw6KOPumMo7jI6\nNTWV2NhYfv/739O9e3eGDBlCbm5umV16P/bYY3Tr1o24uLgq7wHUeEBVvfLCeRWQAnQA6gCrge6l\nysQCP7nK1gfWAT0q2m7v3r21OlmeekjbPfqNzly1x9+hGB/YsGGDR+UcDoeOGzdOAR03blyZ02ci\nPDz8lHmRkZF64MABzcnJ0dzcXFVV3bJlixb/X5o3b55eddVV7vIVlatbt65u375dCwsL9bLLLtNP\nP/1U9+7dq23atNG0tDQtKCjQwYMH6xdffKGqqu3atdP09HTdsWOHBgcH66pVq1RV9aabbtLp06er\nqurAgQN12bJlqqqakZGhnTt3dv/9R44cOaPjUNuV9T0ElqsH526vPX2kqoUiMgb4HggGpqrqehEZ\n7Vo+WVU3ish3wBrAAbytquu8FZM//LAhjZAgYVCXGvtglTkDIsKECRMAmDhxIhMnTgRg3LhxTJgw\nwSvjPBcUFDBmzBiSk5MJDg5my5Ytp13u/PPPp2PHjoCzW+xFixYRGhrKoEGDKL6Kv/3221mwYMFJ\nA9kAdOjQwT22QHlddUdGRhIWFsZ9993H8OHD3d1YG9/xap2Cqs5S1c6q2klV/+GaN1lVJ5co87yq\ndlPVHqr6cvlbq55+3HiQCzo2JrJeqL9DMQGmZGIoVtUJISUlheDgYGJiYpgwYQLNmjVj9erVLF++\nnPz8/DLXqahc6dhOJ9aS3UqX1y11SEgIS5cu5cYbb+Sbb75xd+ZnfMffFc012o6MHLalZXNZbDN/\nh2ICkLrqEEoqWcdwttLT0xk9ejRjxoxBRMjKyqJFixYEBQUxffp0ioqKgFO7YC6vHMDSpUvZsWMH\nDoeDjz/+mAEDBnD++eczf/58MjIyKCoqYsaMGWV2V12ekvvPzs4mKyuLK6+8kgkTJrB69eoqORbG\nc5YUvOjHDc7xXS0pmNKKE8LEiRMZN24cDoeDcePGMXHixLNKDLm5ue5HUi+77DKGDBniHuP4wQcf\n5N1336VXr15s2rTJPeBNXFwcwcHB9OrViwkTJpRbDqBv376MGTOG2NhYOnTowIgRI2jRogX/+te/\nGDx4ML169aJ3795ce23pJknlK+7SOz4+nmPHjjF8+HDi4uIYMGAAL7300hkdB3PmrOtsL/rtm4s5\nmlvAd38se9QrU/OcTtfZiYmJZGZmum8ZFSeKqKioKnsCqSolJSXxwgsv8M033/g7FFOJs+k623pJ\n9ZIjOfksTz3MQ4PP8XcoJkAlJiaiqu778sV1DN6oZDbGU5YUvGTupjQcCpd3s1tHpnxnU3Hra4MG\nDWLQoEH+DsN4mdUpeMlPmw7SrGFderSM9HcoxhjjMUsKXlBQ5GDhlgwGd4mxsRNqoepWT2dqlrP9\n/llS8IIVO49w7EShNVirhcLCwjh06JAlBuMXqsqhQ4cICws7421YnYIXzNucRmiw0N86wKt1Wrdu\nzZ49e6iOHTeamiEsLIzWrVuf8fqWFLxg/uZ0+rZvTIMwa8Vc24SGhtKhQwd/h2HMGbPbR1VsX2Yu\nmw4cY7DdOjLGVEOWFKpY0mbnbYPBXatXF9/GGAOWFKrcvM1ptIqqR6foCH+HYowxp63adXMhIunA\nzjNcvSmQUYXhVJVAjQsCNzaL6/RYXKenJsbVTlUrvYVR7ZLC2RCR5Z70/eFrgRoXBG5sFtfpsbhO\nT22Oy24fGWOMcbOkYIwxxq22JYUp/g6gHIEaFwRubBbX6bG4Tk+tjatW1SkYY4ypWG27UjDGGFOB\nGpkURGSYiGwWkW0i8lgZy0VEXnEtXyMiCT6IqY2IzBORDSKyXkTGlVFmkIhkiUiy6/Wkt+Ny7TdV\nRNa69nnKsHZ+Ol5dShyHZBE5KiJ/LFXGZ8dLRKaKSJqIrCsxr7GI/CAiW13/Nipn3Qq/j16I63kR\n2eT6rL4Qkahy1q3wc/dCXIkisrfE53VlOev6+nh9XCKmVBFJLmddrxyv8s4Nfvt+qWqNegHBwHag\nI1AHWA10K1XmSmA2IEA/4FcfxNUCSHC9bwBsKSOuQcA3fjhmqUDTCpb7/HiV8ZkewPmctV+OF3AJ\nkACsKzHv38BjrvePAc+dyffRC3ENAUJc758rKy5PPncvxJUI/NmDz9qnx6vU8heBJ315vMo7N/jr\n+1UTrxTOB7apaoqq5gMfAaVHEb8WeE+dlgBRItLCm0Gp6n5VXel6fwzYCLTy5j6rkM+PVymXAttV\n9UwbLZ41VV0AHC41+1rgXdf7d4HryljVk+9jlcalqnNUtdA1uQQ48y4zqzAuD/n8eBUT57B3vwVm\nVNX+PIypvHODX75fNTEptAJ2l5jew6knX0/KeI2ItAfOA34tY/FFrsv+2SLS3UchKfCjiKwQkVFl\nLPfr8QJuofz/qP44XsWaqep+1/sDQFljr/r72N2L8yqvLJV97t7wB9fnNbWc2yH+PF4XAwdVdWs5\ny71+vEqdG/zy/aqJSSGgiUgE8F/gj6p6tNTilUBbVY0DXgVm+iisAaoaD1wBPCQil/hov5USkTrA\nNcCnZSz21/E6hTqv5QPqUT4R+StQCHxQThFff+5v4LzNEQ/sx3mrJpDcSsVXCV49XhWdG3z5/aqJ\nSWEv0KbEdGvXvNMtU+VEJBTnh/6Bqn5eermqHlXVbNf7WUCoiDT1dlyqutf1bxrwBc5L0pL8crxc\nrgBWqurB0gv8dbxKOFh8G831b1oZZfz1XbsHGA7c7jqhnMKDz71KqepBVS1SVQfwVjn789fxCgGu\nBz4ur4w3j1c55wa/fL9qYlJYBpwrIh1cvzJvAb4qVeYr4C7XUzX9gKwSl2le4bpf+R9go6q+VE6Z\n5q5yiMj5OD+fQ16OK1xEGhS/x1lJua5UMZ8frxLK/fXmj+NVylfA3a73dwNfllHGk+9jlRKRYcAj\nwDWqerycMp587lUdV8l6qBHl7M/nx8vlMmCTqu4pa6E3j1cF5wb/fL+quiY9EF44n5bZgrNW/q+u\neaOB0a73ArzmWr4W6OODmAbgvPxbAyS7XleWimsMsB7nEwRLgIt8EFdH1/5Wu/YdEMfLtd9wnCf5\nyBLz/HK8cCam/UABzvu29wFNgJ+ArcCPQGNX2ZbArIq+j16OaxvO+8zF37PJpeMq73P3clzTXd+f\nNThPXC0C4Xi55k8r/l6VKOuT41XBucEv3y9r0WyMMcatJt4+MsYYc4YsKRhjjHGzpGCMMcbNkoIx\nxhg3SwrGGGPcLCkYv3K1NfhIRLa7ug+YJSKdKygfJSIPlpgeJCLfnMX+z2r909m+6/1F3tpXqf1+\nJiIdXe+zy1ieIiJdSs17WUQeFZGeIjLNF3GawGNJwfiNq9HOF0CSqnZS1d7A45Tdx0uxKODBCpYH\nskGA15OCqw+oYFVNqaDYRzgbOhWvEwTcCHykqmuB1iLS1ruRmkBkScH402CgQFUnF89Q1dWqulBE\nIkTkJxFZKc4+7It7fvwX0Emcfdo/75oX4fplvElEPijRyvlSEVnlWn+qiNR1zR/mKrsSZ9cGuOaH\nu8otda13Sm+Trquaq0pMTxORG0UkTETece1rlYgMLrVee5wN78a7Yr9YRK4WkV9d5X8UkWaustHi\n7D9/vYi8LSI7xdV9h4jc4YovWUTeFJHgMo7r7ZTR+lVEmorIYlf8M4CbSyy+BNip/+uJ9mtKJA1T\ni1Rla0F72et0XsBYYEI5y0KAhq73TXG20hWgPSf30T8IyMLZ50sQsBhnC9EwnK16O7vKvQf8scT8\nc13b+wTXmAzAP4E7XO+jcLYSDS8V1wjgXdf7Oq5t1QP+BEx1ze8K7HLta1CJ7SdSYjwBoBH/GxL3\nd8CLrveTgMdd74fhbO3aFIjFebIOdS17HbirjGM3H+hZYjob59XXr8DlJeavA3q53k8GxpRY1h/4\n2t/fEXv5/hVSedowxi8E+Kc4e6J04OwOuLzbSkvV1WeNOEfNag8cA3ao6hZXmXeBh4Ak1/ytrvLv\nA8XdIA8BrhGRP7umw4C2OPu3LzYbmOi66hgGLFDVXBEZgLOnVlR1k4jsBMqtG3FpDXzs6hOoDrDD\nNX8AzuSDqn4nIkdc8y8FegPLXBdD9Si7k7QWQHqJ6VCc3SU8pKrzS8yfAdwiIutx9tX/VIllaTi7\nUzC1jCUF40/rcd7HLsvtQDTQW1ULRCQV50m6LCdKvC/izL/XAtygqpvLK6CqeSKSBAzFefvlozPc\nFziTyEuq+pWIDMJ5JVFZfO+q6uOVlMvl5GNVCKzAGXPJpPARMMc1b42e3BNtmGs7ppaxOgXjT3OB\nulJiwBIRiRORi4FIIM2VEAYD7VxFjuEcsrAym4H2InKOa/pOnCe/Ta75nVzzby2xzvc4B4EprpM4\nr5xtfwyMxDkoy3eueQtxJjJcT0+1dcVQUunYI/lfN8d3l5j/M84RwBCRIThvM4Hz1/6NIhLjWtZY\nRNpxqo3AOSWmFedgO11F5FH3TNXtQAbOeprSPdF2xsu9pprAZEnB+I2qKs7bJJe5HkldD/w/nKNM\nfQD0EZG1wF04T+ao6iHgZxFZV6Kiuaxt5+E8cX/q2oYDZ2+heThvF33rqmguefvl7zhvtaxxxfL3\ncjY/BxgI/KjOIRDBeX8/yLWvj4F7VPVEqfW+BkYUVzTjvDL4VERW4Dw5F3saGCLOweVvch2PY6q6\nAXgCmCMia4AfcN4qKu1bnHUZJY9HEc4E+JuSj/TiTAZdgdLjewx2bcfUMtZLqjEBxlVfUaSqhSJy\nIfCGOkf88nT9esA8oL8rGZzJ/ufjHGmssLLypmaxpGBMgBGRc3E+FRUE5AMPquqy09zGUJyDtuw6\nw/23UtWk013XVH+WFIwxxrhZnYIxxhg3SwrGGGPcLCkYY4xxs6RgjDHGzZKCMcYYN0sKxhhj3P4/\nTGxnE0XC8WwAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7fd3fca7cac8>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "vs = np.linspace(0, 20, 100)\n",
+    "\n",
+    "deg = len(cathode_kv) - 4\n",
+    "coeffs = np.polyfit(cathode_kv, vdrift_kmpers, deg=deg)\n",
+    "plt.plot(vs, np.polyval(coeffs, vs), label='%dth degree polynomial fit' % deg)\n",
+    "plt.scatter(cathode_kv, vdrift_kmpers, marker='x', c='k', label='Datapoints')\n",
+    "\n",
+    "plt.ylim(0.5, 1.7)\n",
+    "plt.legend(loc='lower right')\n",
+    "plt.xlabel(\"Cathode voltage (kV)\")\n",
+    "plt.ylabel(\"Drift velocity (km/sec)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 150,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.text.Text at 0x7fd3fcaf0c50>"
+      ]
+     },
+     "execution_count": 150,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZQAAAEKCAYAAAA1qaOTAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3X18XVWd7/HPl2LluUVTEJrG1rTAMN5qMRKsD2h5KqBU\nr14HSgTxjr3VCfVZi3i93peOw2tUdDpFagfRckN4EPVancozVq+R2JRgoGAlqVpSizQqGUbEUvjd\nP/ZOOUmTnN1mn5yek+/79TqvnL32Omf9din5da2191qKCMzMzMbqgHIHYGZm1cEJxczMcuGEYmZm\nuXBCMTOzXDihmJlZLpxQzMwsF04oZmaWCycUMzPLRVkTiqSFkjZL6pa0fJjzkrQiPd8l6aSCcx+S\ntEnSg5JukHTQ+EZvZmaFDixXw5ImAVcBZwC9wAZJayPioYJqZwNz0lcjcDXQKGk6sAw4MSL+Iulm\n4Hzgm6O1WVNTEzNnzsz7UszMqtrGjRv7ImJasXplSyjAyUB3RGwBkHQjsAgoTCiLgOsiWR/mXklT\nJR2TnjsQOFjSM8AhwO+KNThz5kw6OjryvAYzs6on6bdZ6pVzyGs68GjBcW9aVrRORGwDvghsBbYD\n/RFx+3CNSFoiqUNSx44dO3IL3szMBqvISXlJR5L0XmYBxwKHSmoarm5ErI6IhohomDataI/NzMz2\nUTkTyjZgRsFxbVqWpc7pwK8jYkdEPAN8B5hfwljNzKyIciaUDcAcSbMkTSaZVF87pM5a4KL0bq9T\nSIa2tpMMdZ0i6RBJAk4DHh7P4M3MbLCyTcpHxC5JzcBtwCTg2ojYJGlpen4VsA44B+gGngIuSc+1\nS7oFuA/YBXQCq8f/KszMbIAm0gZbDQ0N4bu8nrdqfQ9za6cwv75md1lbTx9dvf0sPbW+jJGZ2f5E\n0saIaChWryIn5S0fc2un0NzaSVtPH5Akk+bWTubWTilzZGZWicr5HIqV2fz6GlYunkdzaydNjXW0\ntG9l5eJ5g3osZmZZuYcywc2vr6GpsY4Vd3fT1FjnZGJm+8wJZYJr6+mjpX0ryxbMpqV96+7hLzOz\nveWEMoENzJmsXDyPD595/O7hLycVM9sXTigTWFdv/6A5k4E5la7e/jJHZmaVyLcNm5nZqHzbsJmZ\njSsnFDMzy4UTipmZ5cIJxczMcuGEYmZmuXBCMTOzXDihmJlZLpxQzMwsF04oZmaWCycUMzPLhROK\nmZnlwgnFzMxy4YRiZma5cEIxM7NclDWhSFooabOkbknLhzkvSSvS812STio4N1XSLZJ+KelhSa8Z\n3+jNzKxQ2RKKpEnAVcDZwInABZJOHFLtbGBO+loCXF1w7l+AWyPiBOAVwMMlD9rMzEZUzh7KyUB3\nRGyJiJ3AjcCiIXUWAddF4l5gqqRjJE0B3gB8HSAidkbEE+MZvJmZDVbOhDIdeLTguDcty1JnFrAD\n+IakTknXSDq0lMGamdnoKnVS/kDgJODqiJgH/BnYYw4GQNISSR2SOnbs2DGeMZqZTSjlTCjbgBkF\nx7VpWZY6vUBvRLSn5beQJJg9RMTqiGiIiIZp06blEriZme2pnAllAzBH0ixJk4HzgbVD6qwFLkrv\n9joF6I+I7RHxGPCopOPTeqcBD41b5GZmtocDy9VwROyS1AzcBkwCro2ITZKWpudXAeuAc4Bu4Cng\nkoKvuBS4Pk1GW4acMzOzcaaIKHcM46ahoSE6OjrKHYaZWUWRtDEiGorVq9RJeTMz2884oZiZWS6c\nUMzMLBdOKGZmlgsnFDMzy4UTipmZ5cIJxczMcuGEYmZmuXBCMTOzXDihmJlZLpxQzMwsF04oZmaW\nCycUMzPLhROKmZnlwgnFzMxy4YRiZma5cEIxM7NcOKGYmVkunFDMzCwXTihWlVat76Gtp29QWVtP\nH6vW95QpIrPq54RiVWlu7RSaWzt3J5W2nj6aWzuZWzulzJGZVa9MCUXSAZLmSTpX0gJJR+XRuKSF\nkjZL6pa0fJjzkrQiPd8l6aQh5ydJ6pT0gzziseoxv76GlYvn0dzayZW3b6a5tZOVi+cxv76m3KGZ\nVa0DRzspqR74BHA68AiwAzgIOE7SU8DXgDUR8dzeNixpEnAVcAbQC2yQtDYiHiqodjYwJ301Alen\nPwd8AHgYOGJv27fqN7++hqbGOlbc3c2yBbOdTMxKrFgP5XNAC1AfEWdFRFNEvCMi5gLnAVOAd+1j\n2ycD3RGxJSJ2AjcCi4bUWQRcF4l7gamSjgGQVAucC1yzj+1blWvr6aOlfSvLFsympX3rHnMqZpav\nUXsoEXHBKOceB74yhranA48WHPcyuPcxUp3pwPa07Y8Dh48hBqtSA3MmA8Ncp9S/2MNeZiW2V5Py\nkmZLapH0bUmvKVVQGeJ4M/B4RGzMUHeJpA5JHTt27BiH6Gx/0NXbPyh5DMypdPX2lzkys+pVbA7l\noIh4uqDosyS9AoDvA68cQ9vbgBkFx7VpWZY6bwfOk3QOyZzOEZJaIqJpaCMRsRpYDdDQ0BBjiNcq\nyNJT6/com19f496JWQkV66F8X9JFBcfPADOBlwLPjrHtDcAcSbMkTQbOB9YOqbMWuCi92+sUoD8i\ntkfEZRFRGxEz08/dPVwyMTOz8VMsoSwk+df/rZLeAHwUOAt4G3DhWBqOiF1AM3AbyZ1aN0fEJklL\nJS1Nq60DtgDdwL8B7x9Lm2ZmVjqKKD4KJGkK8D9JJsQ/FREV+bhxQ0NDdHR0lDsMM7OKImljRDQU\nq1dsDqUR+BiwE/g88BfgHyVtAz4bEU/kEayZmVW+URMKyYOL5wCHAd+IiNcC50s6FbiJZPjLzMys\naELZRTIJfyhJLwWAiFgPrC9dWGZmVmmKJZTFwP8gSSYXFalrZmYTWLGE8khEfGS0CpIUWWb2zcys\nqhW7bfgeSZdKqisslDQ5XXV4DXBx6cIzM7NKUayHshB4D3CDpFnAEyRPpk8Cbge+EhGdpQ3RzMwq\nQbHFIZ8Gvgp8VdILgBrgL75d2MzMhirWQ9ktIp4hWeXXzMxsD94C2MzMcuGEYmZmuSiaUNJ92+8Z\nj2DMzKxyFU0oEfEs8Fy6QKSZmdmwsk7K/yfwgKQ7gD8PFEbEspJEZWZmFSdrQvlO+jIzK6lV63uY\nWztl0O6abT19dPX2D7sTp+0/Mk3KR8Qa4AZgY/pqTcvMzHI1t3YKza2dtPX0AUkyaW7tZG6tR933\nd5l6KJLeCKwBfgMImCHp4oj4celCM7OJaH59DSsXz6O5tZOmxjpa2reycvG8QT0W2z9lHfL6EnBm\nRGwGkHQcSY/lVaUKzMwmrvn1NTQ11rHi7m6WLZjtZFIhsj6H8oKBZAIQEb8CXlCakMxsomvr6aOl\nfSvLFsympX3r7uEv279l7aF0SLoGaEmPLwS8ObuZ5W5gzmRgmOuU+hcPOrb9V9YeyvuAh4Bl6euh\ntMzMLFddvf2DksfAnEpXb3+ZI7NiVGxvLEmTgOsi4sLxCal0GhoaoqPDHSszs70haWNENBSrl/VJ\n+ZdKmpxLZAUkLZS0WVK3pOXDnJekFen5LkknpeUzJN0j6SFJmyR9IO/YzMxs72SdQ9kC/FTSWgY/\nKX/lvjac9nyuAs4AeoENktZGxEMF1c4G5qSvRuDq9Ocu4CMRcZ+kw4GNku4Y8lkzMxtHWRNKT/o6\nADg8p7ZPBrojYguApBuBRSTzMwMWkQy3BXCvpKmSjomI7aR7s0TEk5IeBqYP+ayZmY2jogkl7Ukc\nHhEfzbnt6cCjBce9JL2PYnWmU7DRl6SZwDygfbhGJC0BlgDU1dWNMWQzMxtJ1jmU145DLHtN0mHA\nt4EPRsR/DFcnIlZHRENENEybNm18AzQzm0CyDnndn86ffIvBcyhjWTByGzCj4Lg2LctUJ93j/tvA\n9WOMw8zMcpA1oRwE/AFYUFAWjG0F4g3AHEmzSJLE+cDiIXXWAs3p/Eoj0B8R2yUJ+Drw8FhuDDAz\ns/xkSigRcUneDUfELknNwG3AJODaiNgkaWl6fhWwDjgH6AaeAgbieC3wLpI9Wu5Pyz4ZEevyjNHL\naJuZZZd1teHjSG7ZPToiXi5pLnBeRHxuLI2nCWDdkLJVBe8D+IdhPvf/SFY9LqmBZbQHntotXBLC\nzMwGy7r0yr8BlwHPAEREF8kQVVUrXEb7yts3ez0hM7NRZE0oh0TEz4eU7co7mP1R4TLaTY11TiZm\nZiPImlD6JNWTTMQj6R0UPAtSzbyMtplZNlnv8voHYDVwgqRtwK9JlrCval5G28wsu6x3eW0BTpd0\nKHBARDxZ2rD2D6Mto+2EYmY2WNHl66uJl683M9t7uS1fb2ZmlkWmhCLphVnKzMxs4sraQ/lZxjIz\nM5ugRp2Ul/QSkuXiD5Y0j+efTj8COKTEsZmZWQUpdpfXWcC7SVb5LVyE8UngkyWKyczMKtCoCSUi\n1gBrJL09Ir49TjGZmVkFKjbk1RQRLcBMSR8eet5Lx5uZ2YBiQ14D8ySHlToQMzOrbMUSysCmHw9F\nxLdKHYyZmVWuYrcNn5PujnjZeARjZmaVq1gP5VbgT8Bhkv6joFwk+18dUbLIzMysoozaQ4mIj0XE\nVODfI+KIgtfhTiZmZlYo05PyEbGo1IGYmVll8+KQZmZVatX6nj02BWzr6WPV+p6StOeEYmZWpebW\nTqG5tXN3UhnYNHBu7ZSStJc5oUg6WNLxeTYuaaGkzZK6JS0f5rwkrUjPd0k6KetnzcwmuoFNAZtb\nO7ny9s0l33E26/L1bwHuJ7nrC0mvlLR2LA1LmgRcBZwNnAhcIOnEIdXOBuakryXA1XvxWTOzCW9+\nfQ1NjXWsuLubpsa6ku42m7WH8hngZOAJgIi4H5g1xrZPBrojYktE7ARuBIZO/i8CrovEvcBUScdk\n/KyZ2YTX1tNHS/tWli2YTUv71j3mVPKUNaE8ExH9Q8rGunfwdODRguPetCxLnSyfNTOb0AbmTFYu\nnseHzzx+9/BXqZJK1oSySdJiYJKkOZL+FWgrSUQ5k7REUoekjh07dpQ7HDOzcdPV2z9ozmRgTqWr\nd2j/IB9ZE8qlwN8CfwVagX7gg2Nsexswo+C4Ni3LUifLZwGIiNUR0RARDdOmTRtjyGZmlWPpqfV7\nzJnMr69h6an1I3xibLImlBMi4vKIeHX6+lREPD3GtjcAcyTNkjQZOB8YOtG/FrgovdvrFKA/IrZn\n/KyZmY2jYmt5DfhSuh3wLcBNEfHgWBuOiF2SmoHbgEnAtRGxSdLS9PwqYB1wDtANPAVcMtpnxxqT\nmZntO0Vkm1tPE8o7gb8j2VP+poj4XAljy11DQ0N0dHSUOwwzs4oiaWNENBSrl/nBxoh4LCJWAEtJ\nnkn59BjiMzOzKpP1wca/kfQZSQ8AA3d41ZY0MjMzqyhZ51CuBW4CzoqI35UwHjMzq1CZEkpEvKbU\ngZiZWWUbNaFIujki3pkOdRXO3g/s2Di3pNGZmVnFKNZD+UD6882lDsTMzCpbsS2At6dv3x8Rvy18\nAe8vfXhmZlYpst42fMYwZWfnGYiZmVW2YnMo7yPpibxMUlfBqcOBn5YyMDMzqyzF5lBagR8C/wQU\n7or4ZET8sWRRmZlZxRk1oaR7oPQDFwBIOgo4CDhM0mERsbX0IZqZWSXIvAWwpEeAXwPrgd+Q9FzM\nzMyA7JPynwNOAX4VEbOA04B7SxaVmZlVnL3ZAvgPwAGSDoiIe4CiK0+amdnEkXUtryckHQb8GLhe\n0uPAn0sXlpmZVZqsPZRFwF+ADwG3Aj3AW0oVlJmZVZ6si0MW9kbWlCgWMzOrYMUebHySYRaF5PnF\nIY8oYWxmZlZBij2Hcvh4BWJmZpUt8xbAkl4n6ZL0fY2kWaULy8zMKk3WBxv/F/AJ4LK0aDLQUqqg\nzMzGw6r1PbT19A0qa+vpY9X6njJFVNmy9lDeBpxHeqtwug2wh8PMrKLNrZ1Cc2vn7qTS1tNHc2sn\nc2unlDmyypQ1oeyMiCCdoJd06FgalfQiSXdIeiT9eeQI9RZK2iypW9LygvIvSPqlpC5J35U0dSzx\nmNnENL++hpWL59Hc2smVt2+mubWTlYvnMb++ptyhVaSsCeVmSV8Dpkp6L3AncM0Y2l0O3BURc4C7\nGLySMQCSJgFXkey7ciJwgaQT09N3AC9PtyD+Fc8PxZmZ7ZX59TU0Ndax4u5umhrrnEzGIFNCiYgv\nArcA3waOBz4dESvG0O4inn+eZQ3w1mHqnAx0R8SWiNgJ3Jh+joi4PSJ2pfXuBWrHEIuZTWBtPX20\ntG9l2YLZtLRv3WNOxbLLuvQKEXEHSc8ASQdIujAirt/Hdo8u2F74MeDoYepMBx4tOO4FGoep9x7g\nppEakrQEWAJQV1e3T8GaWXUamDMZGOY6pf7FHvYag1F7KJKOkHSZpJWSzlSiGdgCvLPIZ++U9OAw\nr0WF9QrnZvaWpMuBXcCIiS0iVkdEQ0Q0TJs2bV+aMbMq1dXbPyh5DMypdPX2lzmyylSsh/J/gD8B\nPwP+HvgkyVPyb42I+0f7YEScPtI5Sb+XdExEbJd0DPD4MNW2ATMKjmvTsoHveDfwZuC0NCmZme2V\npafW71E2v77GvZN9VCyhvCwi/guApGuA7UBdRDw9xnbXAhcDV6Q/vzdMnQ3AnPQBym3A+cDiNJaF\nwMeBUyPiqTHGYmZmOSg2Kf/MwJuIeBbozSGZQJJIzkh3gTw9PUbSsZLWpe3tApqB24CHgZsjYlP6\n+ZUkz8HcIel+SatyiMnMzMZAo40WSXqW5/c9EXAw8BQVujhkQ0NDdHR0lDsMM7OKImljRBTdVLHY\n4pCT8gvJzMyqWebFIc3MzEbjhGJmZrlwQjEzs1w4oZiZWS6cUMzMLBdOKGZmlgsnFDMzy4UTipmZ\n5cIJxczMcuGEYmZmuXBCMcvBqvU9e+z019bTx6r1PWWKyGz8OaGY5WBu7RSaWzt3J5WBnQDn1k4p\nc2Rm4yfzFsBmNrKBnf6aWztpaqyjpX2rt5G1Ccc9FLOczK+voamxjhV3d9PUWOdkYhOOE4pZTtp6\n+mhp38qyBbNpad+6x5yKWbVzQjHLwcCcycrF8/jwmcfvHv5yUrGJxAnFLAddvf2D5kwG5lS6evvL\nHJnZ+Bl1C+Bq4y2Azcz2XtYtgN1DMTOzXDihmJlZLsqSUCS9SNIdkh5Jfx45Qr2FkjZL6pa0fJjz\nH5EUknx/pplZmZWrh7IcuCsi5gB3pceDSJoEXAWcDZwIXCDpxILzM4Azga3jErGZmY2qXAllEbAm\nfb8GeOswdU4GuiNiS0TsBG5MPzfgy8DHgYlzV4GZ2X6sXAnl6IjYnr5/DDh6mDrTgUcLjnvTMiQt\nArZFxC9KGqWZmWVWsrW8JN0JvGSYU5cXHkRESMrcy5B0CPBJkuGuLPWXAEsA6urqsjZjZmZ7qWQJ\nJSJOH+mcpN9LOiYitks6Bnh8mGrbgBkFx7VpWT0wC/iFpIHy+ySdHBGPDRPHamA1JM+h7Ov1mJnZ\n6Mo15LUWuDh9fzHwvWHqbADmSJolaTJwPrA2Ih6IiKMiYmZEzCQZCjtpuGRiZmbjp1wJ5QrgDEmP\nAKenx0g6VtI6gIjYBTQDtwEPAzdHxKYyxWtmZkWUZT+UiPgDcNow5b8Dzik4XgesK/JdM/OOz8zM\n9p6flDczs1w4oZiZWS6cUMzMLBdOKGZmlgsnFDMzy4UTipmZ5cIJxczMcuGEYmZmuXBCMTOzXDih\nmJlZLpxQzMwsF04oNi5Wre+hradvUFlbTx+r1veUKSIzy5sTio2LubVTaG7t3J1U2nr6aG7tZG7t\nlDJHZmZ5KctqwzbxzK+vYeXieTS3dtLUWEdL+1ZWLp7H/PqacodmZjlxD8XGzfz6Gpoa61hxdzdN\njXVOJmZVxgllP1Lt8wxtPX20tG9l2YLZtLRv3eNazayyOaHsR6p5nmHgWlYunseHzzx+9/CXk4pZ\n9VBElDuGcdPQ0BAdHR3lDmNUA794q22eYdX6HubWThl0LW09fXT19rP01PoyRmZmxUjaGBENxep5\nUn4/UzjPsGzB7KpIJsCwSWN+fU3VXJ+Zechrv+N5BjOrVE4o+xHPM5hZJStLQpH0Ikl3SHok/Xnk\nCPUWStosqVvS8iHnLpX0S0mbJP3z+EReWl29/YPmTAae3ejq7S9zZGZmxZVlUj5NAH+MiCvSRHFk\nRHxiSJ1JwK+AM4BeYANwQUQ8JOlNwOXAuRHxV0lHRcTjxdqthEl5M7P9TdZJ+XINeS0C1qTv1wBv\nHabOyUB3RGyJiJ3AjennAN4HXBERfwXIkkzMzKy0ypVQjo6I7en7x4Cjh6kzHXi04Lg3LQM4Dni9\npHZJ6yW9unShmplZFiW7bVjSncBLhjl1eeFBRISkvR13OxB4EXAK8GrgZkkvi2HG7yQtAZYA1NXV\n7WUzZmaWVckSSkScPtI5Sb+XdExEbJd0DDDckNU2YEbBcW1aBklv5TtpAvm5pOeAGmDHMHGsBlZD\nMoeyTxdjZmZFlWvIay1wcfr+YuB7w9TZAMyRNEvSZOD89HMA/xd4E4Ck44DJgO+tNTMro3Ld5fVi\n4GagDvgt8M6I+KOkY4FrIuKctN45wFeAScC1EfGPaflk4FrglcBO4KMRcXeGdnek7e2LGqo7aVXz\n9fnaKlc1X18lXdtLI2JasUoTai2vsZDUkeW2uUpVzdfna6tc1Xx91XhtflLezMxy4YRiZma5cELJ\nbnW5Ayixar4+X1vlqubrq7pr8xyKmZnlwj0UMzPLhRNKBpImSeqU9INyx5I3SVMl3ZKu3PywpNeU\nO6a8SPpQuhr1g5JukHRQuWMaC0nXSnpc0oMFZZlW7t7fjXBtX0j/XnZJ+q6kqeWMcSyGu76Ccx+R\nFJIqfrc5J5RsPgA8XO4gSuRfgFsj4gTgFVTJdUqaDiwDGiLi5STPMp1f3qjG7JvAwiFly4G7ImIO\ncFd6XIm+yZ7Xdgfw8oiYS7Ly+GXjHVSOvsme14ekGcCZwNbxDqgUnFCKkFQLnAtcU+5Y8iZpCvAG\n4OsAEbEzIp4ob1S5OhA4WNKBwCHA78ocz5hExI+BPw4pzrJy935vuGuLiNsjYld6eC/J8ksVaYT/\ndgBfBj4OVMVkthNKcV8h+Q/+XLkDKYFZJOuffSMd0rtG0qHlDioPEbEN+CLJv/y2A/0RcXt5oyqJ\nLCt3V4P3AD8sdxB5krQI2BYRvyh3LHlxQhmFpDcDj0fExnLHUiIHAicBV0fEPODPVO6QySDpXMIi\nkqR5LHCopKbyRlVa6WKpVfEv3UKSLgd2AdeXO5a8SDoE+CTw6XLHkicnlNG9FjhP0m9INvhaIKml\nvCHlqhfojYj29PgWkgRTDU4Hfh0ROyLiGeA7wPwyx1QKv09X7GaUlbsrlqR3A28GLhxue4oKVk/y\nj51fpL9faoH7JA235UfFcEIZRURcFhG1ETGTZEL37oiomn/lRsRjwKOSjk+LTgMeKmNIedoKnCLp\nEEkiubaquOFgiCwrd1ckSQtJhpvPi4inyh1PniLigYg4KiJmpr9feoGT0v8nK5YTil0KXC+pi2T1\n5s+XOZ5cpL2uW4D7gAdI/q5X9JPJkm4AfgYcL6lX0n8HrgDOkPQISa/sinLGuK9GuLaVwOHAHZLu\nl7SqrEGOwQjXV3X8pLyZmeXCPRQzM8uFE4qZmeXCCcXMzHLhhGJmZrlwQjEzs1w4oVhVkPQSSTdK\n6pG0UdI6SceNUn+qpPcXHL9xLKtJj/Xze/P96fuSP6Qp6TdDV8CVdI+ks4aUfVDS1aWOx/Z/TihW\n8dIHF78L/Cgi6iPiVSQr0462rtVU4P2jnN+fvZHyPfV/A3uu2nx+Wm4TnBOKVYM3Ac9ExO4H3yLi\nFxHxE0mHSbpL0n2SHkgX5IPkAcD69IG5L6RlhxXsDXN9mqiQdFq6eOYD6b4WL0zLF6Z17wP+60Db\nkg5N6/08/dxAmxTUuVHSuQXH35T0DkkHSfpG2lanpDcN+dxMYCnwoTT210t6i6T2tP6dko5O605L\n90jZlC78+duBHoekpjS++yV9TdKkkf5wJR0s6YeS3kvysOi5kiYXxHMs8JOi/5Ws+kWEX35V9Itk\n35Mvj3DuQOCI9H0N0A0ImAk8WFDvjUA/yZpKB5A81fw64CDgUeC4tN51wAcLyuek33cz8IO0zueB\npvT9VJK9PA4dEtfbgDXp+8npdx0MfAS4Ni0/gWQJmYPS+Aa+/zPARwu+60ief0j574Evpe9XApel\n7xeSLBxZA/wN8H3gBem5rwIXDfNn95v0z+nOwvPAD4BF6fvlwBfL/XfAr/3j5R6KVTsBn0+XlrkT\nmM7IQ2E/j4jeiHgOuJ/kl+nxJItM/iqts4ZkD5kT0vJHIiKAwkVDzwSWS7of+BFJQqgb0tYPgTel\nvZ2zgR9HxF9IklgLQET8EvgtMOJcUKoWuE3SA8DHgL9Ny19HsqgpEXEr8Ke0/DTgVcCGNMbTgJeN\n8N3fA74REdcVlBUOe3m4y3Y7sNwBmOVgE/COEc5dCEwDXhURz6Qru460FfBfC94/y77//yHg7RGx\neaQKEfG0pB8BZwF/R/qLfx/9K3BlRKyV9EaSHkyx+NZERJYdEH8KLJTUmiZOSJLMlyWdBBwS1bu9\ng+0l91CsGtwNvFDSkoECSXMlvR6YQrKnzTPpfMRL0ypPkiw8WMxmYKak2enxu4D1wC/T8vq0/IKC\nz9wGXFowBzNvhO++CbgEeD1wa1r2E5IkSHqXWl0aQ6GhsU8BtqXvLy4o/ynwzvS7ziQZGoNkq+B3\nSDoqPfciSS9leJ8m6dlcNVAQEf8J3ANci3snVsAJxSpe+i/ntwGnp7cNbwL+iWQHw+uBhnQ46CKS\nREBE/AH4qaQHCyblh/vup0l+6X8r/Y7ngFVp+RLg39NJ+cJ9SD4LvADoSmP57AhffztwKnBnROxM\ny74KHJC2dRPw7oj465DPfR9428CkPEmP5FuSNgJ9BfX+N3CmpAeB/5b+eTwZEQ8BnwJuT4cC7wCO\nGenPAPgAyVbK/1xQdgPwCpxQrIBXGzarUun8zLMRsUvSa0h25nxlueOy6uU5FLPqVQfcLOkAYCfw\n3jLHY1VLhSJiAAAAMElEQVTOPRQzM8uF51DMzCwXTihmZpYLJxQzM8uFE4qZmeXCCcXMzHLhhGJm\nZrn4/+PeuIh+K9xFAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7fd3fcad1cf8>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.plot(cathode_kv, 100 * (np.polyval(coeffs, cathode_kv) - vdrift_kmpers)/vdrift_kmpers, \n",
+    "         linestyle='', marker='x')\n",
+    "plt.ylabel('Relative fit error (%)')\n",
+    "plt.xlabel(\"Cathode voltage kV\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Systematic error on drift velocity estimates is around 0.2%, see : https://xecluster.lngs.infn.it/dokuwiki/doku.php?id=xenon:xenon1t:aalbers:drift_and_diffusion#results\n",
+    "\n",
+    "so if the fitter error is much less than this, we're ok."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Make sympy function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 153,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "v = sympy.Symbol('v')\n",
+    "sp_poly = sympy.Poly.from_list(coeffs.tolist(), gens=v)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 155,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.30959670337438"
+      ]
+     },
+     "execution_count": 155,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Sanity check:\n",
+    "sp_poly.subs(dict(v=7.5))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 166,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.30959670337438"
+      ]
+     },
+     "execution_count": 166,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Try converting to and from serialization format, repeat sanity check\n",
+    "serialized_fit = sympy.srepr(sp_poly)\n",
+    "parse_expr(serialized_fit).subs(dict(v=7.5))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Insert in runs db"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 167,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "drift_coll = client['run']['drift_velocity']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 173,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 172,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<pymongo.results.InsertOneResult at 0x7fd3fc0d7ca8>"
+      ]
+     },
+     "execution_count": 172,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Uncomment this, adjust versions and comments to do actual insertion\n",
+    "# drift_coll.insert_one(dict(\n",
+    "#     version='1.0.0',\n",
+    "#     calculation_time=datetime.now(),\n",
+    "#     function=serialized_fit,\n",
+    "#     comment=\"5th degree polynomial fit to Julien&Jelle's Drift velocity results. Jelle, 1 April 2017.\"\n",
+    "# ))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,6 @@ universal = 1
 
 [flake8]
 exclude = docs
+
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ requirements = [
 ]
 
 test_requirements = [
-    # TODO: put package test requirements here
+    'pytest', 'mongomock'
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,11 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     'checksumdir', 'scp', 'pagerduty-api', 'pymongo', 'paramiko',
-    'numpy', 'sympy', 'pytz', 
+    'numpy', 'sympy', 'pytz',
 ]
 
 test_requirements = [
-    'pytest', 'mongomock'
+    'pytest', 'mongomock',
 ]
 
 setup(
@@ -49,6 +49,7 @@ setup(
     ],
     test_suite='tests',
     tests_require=test_requirements,
+    setup_requires=['pytest-runner'],
     entry_points={
         'console_scripts': [
             'cax = cax.main:main',

--- a/tests/common.py
+++ b/tests/common.py
@@ -2,7 +2,7 @@
 
 This will setup a fake runs db and make cax think we're running on midway.
 """
-
+from datetime import datetime
 import os
 import tempfile
 
@@ -39,6 +39,8 @@ def lone_run_collection(request):
             outfile.write("Hi there cax tester!")
 
         runs_collection.insert_one({'number': 1,
+                                    'start': datetime.now(),
+                                    'end': datetime.now(),          # cax checks this to see a run has ended
                                     'data': [
                                         {'host': 'midway-login1',
                                          'location': os.path.abspath(dirname),

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,51 @@
+"""Common test setup for cax
+
+This will setup a fake runs db and make cax think we're running on midway.
+"""
+
+import os
+import tempfile
+
+import mongomock
+import pytest
+
+from cax import config as cax_config
+
+# Check if we could possibly access the real runs db; if so abort the tests.
+# TODO: Probably this is a bit too extreme, and it may mean we can't easily run tests on midway.
+if os.environ.get('MONGO_PASSWORD') is not None:
+    raise RuntimeError("You have the MONGO_PASSWORD environment variable set. "
+                       "It is not safe to run the cax tests with the possibility of accessing the true runs db.")
+
+# Replace cax's mongo_collection with a mongomock collection
+runs_collection = mongomock.MongoClient(cax_config.RUNDB_URI)['run']['runs_new']
+cax_config.mongo_collection = lambda name='runs_new': runs_collection
+
+# Pretend to be midway
+cax_config.HOST = 'midway-login1'
+
+
+@pytest.fixture(params=['transferred', 'verifying', 'error'])
+def lone_run_collection(request):
+    """Fixture that sets the fake runs db to have a single run (numbered 1).
+    The run is deleted from the fake runs db when the test running the fixture exits.
+
+    Using the fixture params, we ensure all tests are run several times for different run transfer statuses.
+    """
+    with tempfile.TemporaryDirectory() as dirname:
+
+        # Create some content standing in for the data
+        with open(os.path.join(dirname, 'example_data.txt'), mode='w') as outfile:
+            outfile.write("Hi there cax tester!")
+
+        runs_collection.insert_one({'number': 1,
+                                    'data': [
+                                        {'host': 'midway-login1',
+                                         'location': os.path.abspath(dirname),
+                                         'status': request.param,
+                                         'type': 'raw'}
+                                    ]})
+
+        yield runs_collection
+
+    runs_collection.delete_many({})

--- a/tests/common.py
+++ b/tests/common.py
@@ -18,8 +18,9 @@ if os.environ.get('MONGO_PASSWORD') is not None:
                        "It is not safe to run the cax tests with the possibility of accessing the true runs db.")
 
 # Replace cax's mongo_collection with a mongomock collection
-runs_collection = mongomock.MongoClient(cax_config.RUNDB_URI)['run']['runs_new']
-cax_config.mongo_collection = lambda name='runs_new': runs_collection
+runs_db = mongomock.MongoClient(cax_config.RUNDB_URI)['run']
+runs_collection = runs_db['runs_new']
+cax_config.mongo_collection = lambda name='runs_new': runs_db[name]
 
 # Pretend to be midway
 cax_config.HOST = 'midway-login1'

--- a/tests/test_cax.py
+++ b/tests/test_cax.py
@@ -1,9 +1,6 @@
-import pytest
-
 # Import the lone_run_collection fixture, which should be given as an argument to any task.
 # flake8 will complain it's not used, please ignore this (just loading the fixture does the magic)
 from .common import lone_run_collection
-
 
 def test_task(lone_run_collection):
     """Tests the task framework by a simple task that looks at the fake runs db.
@@ -42,4 +39,3 @@ def test_checksum(lone_run_collection):
         # (although there is a lot of code that  for status != verifying, this is all unreachable
         # due to a status check at the top, which was probably added later...)
         assert 'checksum' not in data_doc()
-

--- a/tests/test_corrections.py
+++ b/tests/test_corrections.py
@@ -1,0 +1,74 @@
+# Import the lone_run_collection fixture, which should be given as an argument to any test.
+# flake8 will complain it's not used, please ignore this (just loading the fixture does the magic)
+from .common import lone_run_collection, runs_db
+import pytest
+from datetime import datetime
+
+from cax.tasks.corrections import CorrectionBase
+
+class ElectronHappinessCorrection(CorrectionBase):
+    key = 'processor.DEFAULT.electron_happiness_liquid'
+    collection_name='electron_happiness'
+
+    def evaluate(self):
+        return float(self.evaluate_function())
+
+
+@pytest.fixture()
+def correction_collection():
+    """Fixture that creates a correction collection with a single entry, then cleans it up
+    """
+    corr_collection = runs_db['electron_happiness']
+    corr_collection.insert_one(dict(
+        calculation_time=datetime.now(),
+        version='1.0.0',
+        comment='Very nice correction',
+        function='1',           # Notice it's a string: this is evaluated as a sympy expression.
+    ))
+    yield corr_collection
+    corr_collection.delete_many({})
+
+
+def test_correction(lone_run_collection, correction_collection):
+    t = ElectronHappinessCorrection()
+    t.go()
+
+    def get_run_doc():
+        return lone_run_collection.find_one({})
+
+    # Check the correction has been inserted
+    run_doc = get_run_doc()
+    assert 'processor' in run_doc
+    assert 'DEFAULT' in run_doc['processor']
+    assert 'electron_happiness_liquid' in run_doc['processor']['DEFAULT']
+    assert run_doc['processor']['DEFAULT']['electron_happiness_liquid'] == 1
+
+    # Check the version was inserted
+    assert 'correction_versions' in run_doc['processor']
+    assert 'ElectronHappinessCorrection' in run_doc['processor']['correction_versions']
+    assert run_doc['processor']['correction_versions']['ElectronHappinessCorrection'] == '1.0.0'
+
+    # Check that the correction is NOT recalculated when the correction version hasn't changed
+    correction_collection.find_one_and_update({},
+                                              {'$set': {'function': '2'}})
+    t.go()
+    run_doc = get_run_doc()
+    assert run_doc['processor']['DEFAULT']['electron_happiness_liquid'] == 1
+
+    # Check it IS recalculated when the version changes
+    correction_collection.find_one_and_update({},
+                                              {'$set': {'function': '3',
+                                                        'version': '1.1.0'}})
+    t.go()
+    run_doc = get_run_doc()
+    assert run_doc['processor']['DEFAULT']['electron_happiness_liquid'] == 3
+
+    # Check calculation time will act as version if version is ommitted
+    correction_collection.find_one_and_update({},
+                                              {'$unset': {'version': ''},
+                                               '$set': {'function': '4'}})
+    t.go()
+    run_doc = get_run_doc()
+    assert run_doc['processor']['DEFAULT']['electron_happiness_liquid'] == 4
+    calc_time_string = str(correction_collection.find_one()['calculation_time'])
+    assert run_doc['processor']['correction_versions']['ElectronHappinessCorrection'] == calc_time_string


### PR DESCRIPTION
This adds:
  - Version tracking for corrections (#81) 
  - Tests for cax using a fake runs db
  - Make the drift velocity 'correction' play by the rules (sympy function in runs db), and include Julien's measurements at lower fields.

Correction versioning
--------------------------
As several of you know, our corrections are controlled by documents in special collections in the runs db (e.g. 'purity' for electron lifetime). These contain a sympy function which computes the correction value, as well as a 'creation_time' key, which cax uses to figure out which correction is the most recent (and should therefore be used).

With this pull request:
  * Corrections can be identified by an explicit `version` string in the correction doc. If that's not there, we just use a timestamp string from the `creation_time` key. 
  * For each run doc and each correction, we store the version that was used under `processor.correction_versions`. 
  * If a newer correction version exists, the correction value for a run is recomputed and inserted in the run doc. The run isn't automatically reprocessed, so seeing a correction version in the run doc **does NOT guarantee that correction was used for processing!**.
  * However, the `processor.correction_versions` section will automatically propagate to the pax metadata. Using `hax.paxroot.get_metadata`, we can figure out which corrections were applied during processing (and e.g. decide if a processed file is out of date). 

In the future, it may be best to copy the `processor.correction_versions` to the data entry of the processed data in the run doc once it is created, so we don't need to read metadata using hax to figure out which corrections were used.

Tests with fake runs db
--------------------------
I'm usually too scared to commit anything to cax, since I can't test if it works or just silently corrupts our runs db in an interesting way which we'll find out in three months time... 

This adds a few tests to cax which operate on a fake runs db, provided by mongomock. During tests, cax is monkeypatched to return things from this fake db instead of the real db. The tests insert stuff in and remove stuff from the fake db as needed for their purposes. I added three tests:
  * `test_task`, which just tests the basic tasks infrastructure
  * `test_checksum`, which tests if checksums get added under the appropriate conditions
  * `test_corrections`, which tests if the correction versioning stuff described above works.

You run the tests by doing `python setup.py test` or just `pytest`. You cannot run them if you have the MONGO_PASSWORD set in your environment -- this is just an extra safeguard to prevent some operations happening on the real runs db by accident (the tests do things like clearing the (fake) runs db after all).

Drift velocity correction
---------------------------------
I updated the drift velocity correction to use [Julien's results](https://xecluster.lngs.infn.it/dokuwiki/doku.php?id=xenon:xenon1t:julien:xenon1t_drift_velocity&#results) and [my results](https://xecluster.lngs.infn.it/dokuwiki/doku.php?id=xenon:xenon1t:aalbers:drift_and_diffusion#drift_velocity2) (which agree on the 12 kV data):

![vdrift_fit](https://cloud.githubusercontent.com/assets/4354311/24579509/85a1c79c-16f7-11e7-9e3d-012b94214570.png)

I used a high-degree polynomial because I was lazy, obviously there are better functions. At the measured voltages the value of the fit is well within the measurement error (0.2%, see my note linked above):

![vdritf_fit_error](https://cloud.githubusercontent.com/assets/4354311/24579513/8f799704-16f7-11e7-9ac8-eb22950ab33f.png)

Of course using a higher-degree polynomial would walk through the points exactly, but the interpolation would be less reliable (very bumpy). The notebook used to do the fit and conversion to sympy function is included in examples.


CAUTION BEFORE MERGING
---------------------------------
This will cause **all corrections to be recomputed on all runs**, so we have a first guaranteed version number. This includes the PMT gains, which will take some time to compute.

Even though I added tests for the versioning mechanisms, I **could not test the actual correction logic**, though most of it hasn't changed. Don't expect a seamless upgrade...

The electron lifetime function (sympy expression from purity collection in runs db) seems to be just `a / (1 + b * exp(-c * t))`. I assume that's the last leg of our [electron lifetime model](https://xecluster.lngs.infn.it/dokuwiki/doku.php?id=xenon:xenon1t:analysis:firstresults:elife). That means  using this on anything before the last discontinuity will give incorrect electron lifetimes. In the past this didn't matter so much: once assigned, electron lifetimes were never automatically updated -- but now they will be. Thus, the function will **have to be updated to include the full historical model** -- or at least, up to where we might still be interested in reprocessing.

