### PR TITLE
Add '|' character to avoid autonesting by mongo

### DIFF
--- a/cax/tasks/corrections.py
+++ b/cax/tasks/corrections.py
@@ -166,7 +166,7 @@ class AddGains(CorrectionBase):
 
 class SetNeuralNetwork(CorrectionBase):
     '''Set the proper neural network file according to run number'''
-    key = "processor.NeuralNet.PosRecNeuralNet.neural_net_file"
+    key = "processor.NeuralNet|PosRecNeuralNet.neural_net_file"
     collection_name = 'neural_network'
     
     def evaluate(self):


### PR DESCRIPTION
pax will interpret the '|' as a '.' when doing the config override, so the setting will be taken correctly.

