### PR TITLE
Allow processing anywhere

### DIFF
--- a/cax/qsub.py
+++ b/cax/qsub.py
@@ -99,7 +99,7 @@ def get_queue(host=config.get_hostname(), partition=''):
         args = {'partition': 'main',
                 'user' : 'bobau'}
     else:
-        raise ValueError()
+        return []
 
     if partition == '':
         command = 'squeue --user={user} -o "%.30j"'.format(**args)

--- a/cax/tasks/process.py
+++ b/cax/tasks/process.py
@@ -151,9 +151,6 @@ class ProcessBatchQueue(Task):
 
         thishost = config.get_hostname()
 
-        if thishost != 'midway-login1':
-            return
-
         versions = ['v%s' % pax.__version__]
 
         have_processed, have_raw = self.local_data_finder(thishost,

--- a/cax/tasks/process_hax.py
+++ b/cax/tasks/process_hax.py
@@ -70,9 +70,6 @@ class ProcessBatchQueueHax(Task):
     def each_run(self):
 
         thishost = config.get_hostname()
-        
-        if thishost != 'midway-login1':
-            return
 
         version = 'v%s' % pax.__version__
         have_processed, have_raw = self.local_data_finder(thishost,


### PR DESCRIPTION
Remove Midway-only constraint.

This only allows ```cax``` to run locally on e.g. ```xecluster06```.  @malfonsi working on implementing ULITE for ```massive-cax```