### PR TITLE
Download processed files even if past purge threshold

### DIFF
--- a/cax/tasks/data_mover.py
+++ b/cax/tasks/data_mover.py
@@ -314,8 +314,8 @@ class CopyBase(Task):
         # If should be purged, don't pull
         PurgeObj = BufferPurger()
         PurgeObj.run_doc = self.run_doc
-        if option_type == 'download' and PurgeObj.check_purge_requirements():
-            self.log.info("Skip download that would be purged")
+        if option_type == 'download' and data_type == 'raw' and PurgeObj.check_purge_requirements():
+            self.log.info("Skip raw download that would be purged")
             return None, None
 
         start = time.time()


### PR DESCRIPTION
Previously implemented exception for pulling expired raw files was preventing the download of newly processed files.  This just applies the requirement to raw files only, as was originally intended.