### PR TITLE
Added new class in cax/tasks/filesystem.py to add the raw size in byte

### DIFF
--- a/cax/main.py
+++ b/cax/main.py
@@ -117,7 +117,7 @@ def main():
         checksum.AddChecksum(),  # Add checksum for data here so can know if corruption (useful for knowing when many good copies!)
 
         filesystem.SetPermission(),  # Set any permissions (primarily for Tegner) for new data to make sure analysts can access
-        filesystem.AddSize(), # Evaluate the size of the raw files and check that they are complete
+        filesystem.AddSize(),  # Evaluate the size of the raw files and check that they are complete
 
         process.ProcessBatchQueue(),  # Process the data with pax
         process_hax.ProcessBatchQueueHax(),  # Process the data with hax

--- a/cax/main.py
+++ b/cax/main.py
@@ -117,6 +117,8 @@ def main():
         checksum.AddChecksum(),  # Add checksum for data here so can know if corruption (useful for knowing when many good copies!)
 
         filesystem.SetPermission(),  # Set any permissions (primarily for Tegner) for new data to make sure analysts can access
+        filesystem.AddSize(), # Evaluate the size of the raw files and check that they are complete
+
         process.ProcessBatchQueue(),  # Process the data with pax
         process_hax.ProcessBatchQueueHax(),  # Process the data with hax
         clear.PurgeProcessed(),  #Clear the processed data for a given version

--- a/cax/tasks/filesystem.py
+++ b/cax/tasks/filesystem.py
@@ -213,7 +213,7 @@ class AddSize(Task):
                          # The Muon Veto data have one file less respect to the TPC run
                          if ( (nfiles) == (int(ents)) or (nfiles) == (int(ents)+1) ) :
                             self.log.debug("nevnt: %i  nfile: %i" %(nfiles,int(ents) ) )
-                            self.log.debug("Run Name: %s  Number: %d  is on midway: %s" % 
+                            self.log.debug("Run Name: %s  Number: %d  is on midway: %s" %
                                           (run_name,run_number , _location))
                             completeness = True
                          else:
@@ -229,7 +229,7 @@ class AddSize(Task):
                                  #self.log.info(_location+"/"+i)
                                  rfile=_location+"/"+i
                                  byt= os.stat(rfile)
-                                 raw_size += byt.st_size 
+                                 raw_size += byt.st_size
                              self.log.debug("Raw size: %d Byte  %.2f GByte nEvents: %d Size per evnt: %.1f" %
                                             (raw_size,raw_size/1024/1024/1024, nevents,float(raw_size/nevents) ))
 

--- a/cax/tasks/filesystem.py
+++ b/cax/tasks/filesystem.py
@@ -223,7 +223,6 @@ class AddSize(Task):
                     completeness = False
                     raw_size = 0
                     filelist=os.listdir(_location)
-                    print(filelist[0])
                     nfiles = len(os.listdir(_location))-4
                     
                     

--- a/cax/tasks/filesystem.py
+++ b/cax/tasks/filesystem.py
@@ -205,7 +205,7 @@ class AddSize(Task):
         nevents = trigger['events_built']
         ents = int(nevents)/evn_per_zip
         self.log.debug("Number of Events: %d" % (nevents))
-        self.log.debug("Number of Zip Files: %.3f" % (ents))
+        self.log.debug("Number of Zip Files: %i" % (int(ents)+1))
 
         for data_doc in self.run_doc['data']:
 

--- a/cax/tasks/filesystem.py
+++ b/cax/tasks/filesystem.py
@@ -177,12 +177,12 @@ class AddSize(Task):
 
         # Check of data info
         if 'data' not in self.run_doc:
-           self.log.debug("Data not found Name: %s " %(run_name) )
+           self.log.debug("Data not found Name: %s " %(self.run_doc['name']) )
            return
 
         # Check of Trigger info
         if 'trigger' not in self.run_doc: 
-           self.log.debug("Trigger not found Name: %s " %(run_name) )
+           self.log.debug("Trigger not found Name: %s " %(self.run_doc['name']) )
            return
 
         run_number = self.run_doc['number']
@@ -243,9 +243,9 @@ class AddSize(Task):
 
                    except FileNotFoundError:
                       if run_number == 0:
-                          self.log.debug("Run name: %s  Not on mwy"%(run_name,_location))
+                          self.log.debug("Run name: %s  Not on %s "%(run_name,_location))
                       else:
-                          self.log.debug("Run: %i  Name: %s  Not on mwy"%(run_number,run_name,_location))
+                          self.log.debug("Run: %i  Name: %s  Not on %s "%(run_number,run_name,_location))
                       
                       return      
    

--- a/cax/tasks/filesystem.py
+++ b/cax/tasks/filesystem.py
@@ -209,8 +209,7 @@ class AddSize(Task):
                          nfiles = len(os.listdir(_location))-4
 
                          ents = int(nevents)/1000.
-                         res = int((ents-int(ents))*1000.)
-
+                         
                          # The Muon Veto data have one file less respect to the TPC run
                          if ( (nfiles) == (int(ents)) or (nfiles) == (int(ents)+1) ) :
                             self.log.debug("nevnt: %i  nfile: %i" %(nfiles,int(ents) ) )

--- a/cax/tasks/filesystem.py
+++ b/cax/tasks/filesystem.py
@@ -195,16 +195,16 @@ class AddSize(Task):
         if 'trigger_config_override' not in reader['ini']:
             evn_per_zip = 1000
         elif 'Zip' not in reader['ini']['trigger_config_override']:
-            evn_per_zip = 1000 
+            evn_per_zip = 1000
         else:
-            evn_per_zip = reader['ini']['trigger_config_override']['Zip']['events_per_file'] 
+            evn_per_zip = reader['ini']['trigger_config_override']['Zip']['events_per_file']
         
         self.log.debug("Event per zip: %d" % (evn_per_zip))
         
         
         nevents = trigger['events_built']
-        ents = int(nevents)/evn_per_zip 
-        self.log.debug("Number of Events: %d" % (nevents) )
+        ents = int(nevents)/evn_per_zip
+        self.log.debug("Number of Events: %d" % (nevents))
         self.log.debug("Number of Zip Files: %.3f" % (ents))
 
         for data_doc in self.run_doc['data']:

--- a/cax/tasks/filesystem.py
+++ b/cax/tasks/filesystem.py
@@ -187,10 +187,25 @@ class AddSize(Task):
 
         run_number = self.run_doc['number']
         run_name = self.run_doc['name']
-
-
         trigger = self.run_doc['trigger']
+        reader = self.run_doc['reader']
+
+        evn_per_zip = 0
+        
+        if 'trigger_config_override' not in reader['ini']:
+            evn_per_zip = 1000
+        elif 'Zip' not in reader['ini']['trigger_config_override']:
+            evn_per_zip = 1000 
+        else:
+            evn_per_zip = reader['ini']['trigger_config_override']['Zip']['events_per_file'] 
+        
+        self.log.debug("Event per zip: %d" % (evn_per_zip))
+        
+        
         nevents = trigger['events_built']
+        ents = int(nevents)/evn_per_zip 
+        self.log.debug("Number of Events: %d" % (nevents) )
+        self.log.debug("Number of Zip Files: %.3f" % (ents))
 
         for data_doc in self.run_doc['data']:
 
@@ -207,9 +222,11 @@ class AddSize(Task):
                     # Check if the number of files match with the number of events
                     completeness = False
                     raw_size = 0
+                    filelist=os.listdir(_location)
+                    print(filelist[0])
                     nfiles = len(os.listdir(_location))-4
-                    ents = int(nevents)/1000.
-
+                    
+                    
                     if 'raw_size_byte' not in self.run_doc:
                         
                         # The Muon Veto data have one file less respect to the TPC run

--- a/cax/tasks/filesystem.py
+++ b/cax/tasks/filesystem.py
@@ -250,7 +250,7 @@ class AddSize(Task):
                                 raw_size += byt.st_size
                          
                             self.log.debug("Raw size: %d Byte  %.2f GByte nEvents: %d Size per evnt: %.1f" %
-                                             (raw_size,raw_size*10e-9, nevents,float(raw_size/nevents) ))
+                                             (raw_size,raw_size*1e-9, nevents,float(raw_size/nevents) ))
                          
                             self.collection.update( {'_id' : self.run_doc['_id'] },
                                                       {'$set': {'raw_size_byte' : raw_size } } )

--- a/cax/tasks/filesystem.py
+++ b/cax/tasks/filesystem.py
@@ -241,8 +241,7 @@ class AddSize(Task):
                         self.log.debug("Size Raw data: %.2f GB" % (float(self.run_doc['raw_size_byte']/1.e9)))
 
 
-                """Adds the size of the processed files if are present in the local disk """
-
+                #This adds the size of the processed files if are present in the local disk.
                 if ( _type ==  "processed" and _status == "transferred" ):
                    if 'size_byte' not in data_doc:
                        if os.path.isfile(_location):

--- a/cax/tasks/filesystem.py
+++ b/cax/tasks/filesystem.py
@@ -167,11 +167,11 @@ class RemoveSingle(Task):
 class AddSize(Task):
 
     """ Evaluate the file size of a raw data and check if
-        the number of files in the raw data directory match 
+        the number of files in the raw data directory match
         with the number of events recorded
     """
     def __init__(self):
-        Task.__init__(self) 
+        Task.__init__(self)
 
     def each_run(self):
 
@@ -181,24 +181,24 @@ class AddSize(Task):
            return
 
         # Check of Trigger info
-        if 'trigger' not in self.run_doc: 
+        if 'trigger' not in self.run_doc:
            self.log.debug("Trigger not found Name: %s " %(self.run_doc['name']) )
            return
 
         run_number = self.run_doc['number']
-        run_name = self.run_doc['name'] 
+        run_name = self.run_doc['name']
 
 
         trigger = self.run_doc['trigger']
         nevents = trigger['events_built']
 
-        for data_doc in self.run_doc['data']:        
-            
-            _host = data_doc['host']  
-            _location = data_doc['location'] 
-            _type = data_doc['type']  
+        for data_doc in self.run_doc['data']:
 
-            if _host == config.get_hostname():  
+            _host = data_doc['host']
+            _location = data_doc['location']
+            _type = data_doc['type']
+
+            if _host == config.get_hostname():
 
                if _type ==  "raw":
                    self.log.debug("host: %s  location: %s  type: %s" %(_host,_location,_type ) )
@@ -246,7 +246,7 @@ class AddSize(Task):
                       else:
                           self.log.debug("Run: %i  Name: %s  Not on %s "%(run_number,run_name,_location))
                       
-                      return      
+                      return
    
 
 class RemoveTSMEntry(Task):

--- a/cax/tasks/filesystem.py
+++ b/cax/tasks/filesystem.py
@@ -243,7 +243,7 @@ class AddSize(Task):
 
                 #This adds the size of the processed files if are present in the local disk.
                 if ( _type ==  "processed" and _status == "transferred" ):
-                   if 'size_byte' not in data_doc:
+                   if 'size' not in data_doc:
                        if os.path.isfile(_location):
                            byt= os.stat(_location)
                            self.log.debug("Location: %s Size: %i Byte (%.2f GB)"

--- a/cax/tasks/filesystem.py
+++ b/cax/tasks/filesystem.py
@@ -250,7 +250,7 @@ class AddSize(Task):
                                           % (_location, byt.st_size, byt.st_size/1024/1024/1024 ) )
                            self.collection.update({'_id' : self.run_doc['_id'],
                                                'data': {'$elemMatch': data_doc}},
-                                              {'$set': {'data.$.size_byte': byt.st_size } } )
+                                              {'$set': {'data.$.size': byt.st_size } } )
                    else:
                        if os.path.isfile(_location):
                            byt= os.stat(_location)

--- a/cax/tasks/filesystem.py
+++ b/cax/tasks/filesystem.py
@@ -241,9 +241,7 @@ class AddSize(Task):
                         self.log.debug("Size Raw data: %.2f GB" % (float(self.run_doc['raw_size_byte']/1.e9)))
 
 
-                """ 
-                    Adds the size of the processed files if are present in the local disk 
-                """ 
+                """Adds the size of the processed files if are present in the local disk """
 
                 if ( _type ==  "processed" and _status == "transferred" ):
                    if 'size_byte' not in data_doc:

--- a/cax/tasks/filesystem.py
+++ b/cax/tasks/filesystem.py
@@ -222,7 +222,6 @@ class AddSize(Task):
                     # Check if the number of files match with the number of events
                     completeness = False
                     raw_size = 0
-                    filelist=os.listdir(_location)
                     nfiles = len(os.listdir(_location))-4
                     
                     

--- a/cax/tasks/filesystem.py
+++ b/cax/tasks/filesystem.py
@@ -197,56 +197,70 @@ class AddSize(Task):
             _host = data_doc['host']
             _location = data_doc['location']
             _type = data_doc['type']
+            _status = data_doc['status']
 
-            if _host == config.get_hostname():
+            if _type ==  "raw" and _status == "transferred":
+                self.log.debug("host: %s  location: %s  type: %s" %(_host,_location,_type ) )
+                try:
+                      # Check if the number of files match with the number of events
+                      completeness = False
+                      raw_size = 0
+                      nfiles = len(os.listdir(_location))-4
 
-               if _type ==  "raw":
-                   self.log.debug("host: %s  location: %s  type: %s" %(_host,_location,_type ) )
-                   try:
-                         # Check if the number of files match with the number of events
-                         completeness = False
-                         raw_size = 0
-                         nfiles = len(os.listdir(_location))-4
-
-                         ents = int(nevents)/1000.
-                         
-                         # The Muon Veto data have one file less respect to the TPC run
-                         if ( (nfiles) == (int(ents)) or (nfiles) == (int(ents)+1) ) :
-                            self.log.debug("nevnt: %i  nfile: %i" %(nfiles,int(ents) ) )
-                            self.log.debug("Run Name: %s  Number: %d  is on midway: %s" %
-                                          (run_name,run_number , _location))
-                            completeness = True
-                         else:
-                            self.log.debug("!!! Corrupted !!! Expected %d files found %d  Name: %s " %((int(ents)+1), number_files, name) )
-                            completeness = False
-
-                         # If the raw files are complete calculate the size summing the size of
-                         # each file contained in the directory of the raw data
-
-                         if (completeness):
-
-                             for i in os.listdir(_location):
-                                 #self.log.info(_location+"/"+i)
-                                 rfile=_location+"/"+i
-                                 byt= os.stat(rfile)
-                                 raw_size += byt.st_size
-                             self.log.debug("Raw size: %d Byte  %.2f GByte nEvents: %d Size per evnt: %.1f" %
-                                            (raw_size,raw_size/1024/1024/1024, nevents,float(raw_size/nevents) ))
-
-                             self.collection.update({'_id' : self.run_doc['_id'],
-                                                     'data': {'$elemMatch': data_doc}},
-                                                     {'$set': {'data.$.size_byte' : raw_size} } )
-
-     
-                       #print("Path: %s nevnt: %i  nfile: %i" %(path, number_files,
-
-                   except FileNotFoundError:
-                      if run_number == 0:
-                          self.log.debug("Run name: %s  Not on %s "%(run_name,_location))
-                      else:
-                          self.log.debug("Run: %i  Name: %s  Not on %s "%(run_number,run_name,_location))
+                      ents = int(nevents)/1000.
+                      if 'raw_size_byte' not in self.run_doc:
                       
-                      return
+                          # The Muon Veto data have one file less respect to the TPC run
+                          if ( (nfiles) == (int(ents)) or (nfiles) == (int(ents)+1) ) :
+                             self.log.debug("nevnt: %i  nfile: %i" %(nfiles,int(ents) ) )
+                             self.log.debug("Run Name: %s  Number: %d  is on midway: %s" %
+                                           (run_name,run_number , _location))
+                             completeness = True
+                          else:
+                             self.log.debug("!!! Corrupted !!! Expected %d files found %d  Name: %s " %((int(ents)+1), number_files, name) )
+                             completeness = False
+                         
+                          # If the raw files are complete calculate the size summing the size of
+                          # each file contained in the directory of the raw data
+                          if (completeness):
+                         
+                              for i in os.listdir(_location):
+                                  #self.log.info(_location+"/"+i)
+                                  rfile=_location+"/"+i
+                                  byt= os.stat(rfile)
+                                  raw_size += byt.st_size
+                         
+                              self.log.debug("Raw size: %d Byte  %.2f GByte nEvents: %d Size per evnt: %.1f" %
+                                             (raw_size,raw_size*10e-9, nevents,float(raw_size/nevents) ))
+                         
+                         
+                              self.collection.update( {'_id' : self.run_doc['_id'] },
+                                                      {'$set': {'raw_size_byte' : raw_size } } )
+                      else:
+                          self.log.debug("Size Raw data: %.2f GB" % (float(self.run_doc['raw_size_byte']/1.e9)))
+                         
+#                              In the case I want to remove a entry:
+#                              self.collection.update({'_id' : self.run_doc['_id'],
+#                                                      'data': {'$elemMatch': data_doc}},
+#                                                      {'$pull': {'data': { 'raw_size_byte': 413378248} } }, )
+                         
+                           #   else:
+                           #      self.log.info("Raw size already present: %d " % (data_doc['raw_size_byte']) )
+     
+
+
+ 
+                      if ( _type ==  "processed" and _status == "transferred" ):
+                         print("Print Location: %s " % (_location) )
+            
+                  
+                except FileNotFoundError:
+                   if run_number == 0:
+                       self.log.debug("Run name: %s  Not on %s "%(run_name,_location))
+                   else:
+                       self.log.debug("Run: %i  Name: %s  Not on %s "%(run_number,run_name,_location))
+                   
+                   continue
    
 
 class RemoveTSMEntry(Task):


### PR DESCRIPTION
Fixes #86:

I added a new task called `AddSize` to evaluate and check the size of raw data and their completeness.
I tested the script only from midway, but I think it should work on xe1t-datamanager as default before to start the copy with Rucio. 
I didn't set a particular host where it have to work, because in general should be able to verify the raw in each site and then evaluate the size (this is a kind of double check in case of multiple copies of raw data)
To use it is enough add in the task list `"AddSize"`
