### PR TITLE
Fix pax versioning in hax task

### DIFF
--- a/cax/tasks/process_hax.py
+++ b/cax/tasks/process_hax.py
@@ -21,7 +21,8 @@ from cax.task import Task
 
 def init_hax(in_location, pax_version, out_location):
     hax.init(experiment='XENON1T',
-             main_data_paths=[in_location+'pax_'+pax_version],
+             pax_version_policy = pax_version.replace("v",""),
+             main_data_paths=[in_location],
              minitree_paths = [out_location])
 
 def verify():
@@ -36,7 +37,7 @@ def _process_hax(name, in_location, host, pax_version,
              out_location, detector='tpc'):
     """Called by another command.
     """
-    print('Welcome to cax-process')
+    print('Welcome to cax-process-hax')
 
     # Grab the Run DB so we can query it
     collection = config.mongo_collection()
@@ -49,7 +50,7 @@ def _process_hax(name, in_location, host, pax_version,
     os.makedirs(out_location, exist_ok=True)
 
     try:
-        print ('creating hax minitrees', name, in_location)
+        print ('creating hax minitrees for run', name, pax_version, in_location, out_location)
         init_hax(in_location, pax_version, out_location)   # may initialize once only
         hax.minitrees.load_single_dataset(name, ['Corrections', 'Basics', 'Fundamentals',
                                   'DoubleScatter', 'LargestPeakProperties',
@@ -70,36 +71,38 @@ class ProcessBatchQueueHax(Task):
 
         thishost = config.get_hostname()
 
-        version = 'v%s' % pax.__version__
+        hax_version = 'v%s' % hax.__version__
+        pax_version = 'v%s' % pax.__version__
         have_processed, have_raw = self.local_data_finder(thishost,
-                                                          version)
+                                                          pax_version)
 
-        # Skip if no raw data
+        # Skip if no processed data
         if not have_processed:
             self.log.debug("Skipping %s with no processed data", self.run_doc['name'])
             return
 
-        in_location = config.get_processing_dir(thishost,version)
-        out_location = config.get_minitrees_dir(thishost,version)
+        in_location = os.path.dirname(have_processed['location'])
+        out_location = config.get_minitrees_dir(thishost,pax_version)
             
         queue_list = qsub.get_queue(thishost)
-            # Should check version here too
+
+        # Should check version here too
         if self.run_doc['name'] in queue_list:
             self.log.debug("Skipping %s currently in queue",
                            self.run_doc['name'])
             return
 
-        self.log.info("Processing %s with hax_%s, output to %s",
-                      self.run_doc['name'], version, 
+        self.log.info("Processing %s (%s) with hax_%s, output to %s",
+                      self.run_doc['name'], pax_version, hax_version, 
                       out_location)
 
 
         _process_hax(self.run_doc['name'], in_location, thishost,
-                     version, out_location,
+                     pax_version, out_location,
                      self.run_doc['detector'])
 
 
-    def local_data_finder(self, thishost, version):
+    def local_data_finder(self, thishost, pax_version):
         have_processed = False
         have_raw = False
         # Iterate over data locations to know status
@@ -113,14 +116,14 @@ class ProcessBatchQueueHax(Task):
             if datum['host'] != thishost:
                 continue
 
-            # Raw data must exist
+            # Check for raw data 
             if datum['type'] == 'raw' and datum['status'] == 'transferred':
                 have_raw = datum
 
             # Check if processed data already exists in DB
             if datum['type'] == 'processed' and datum['status'] == 'transferred':
-                if version == datum['pax_version']:
-                    have_processed = True
+                if pax_version == datum['pax_version']:
+                    have_processed = datum
                     
         return have_processed, have_raw
 

--- a/cax/tasks/process_hax.py
+++ b/cax/tasks/process_hax.py
@@ -3,17 +3,11 @@
 Performs batch queue operations to run pax.
 """
 
-import datetime
-import hashlib
-import subprocess
 import sys
 import os
-from collections import defaultdict
 
 import pax
 import hax
-import checksumdir
-from pymongo import ReturnDocument
 
 from cax import qsub, config
 from cax.task import Task
@@ -21,9 +15,10 @@ from cax.task import Task
 
 def init_hax(in_location, pax_version, out_location):
     hax.init(experiment='XENON1T',
-             pax_version_policy = pax_version.replace("v",""),
+             pax_version_policy=pax_version.replace("v", ""),
              main_data_paths=[in_location],
-             minitree_paths = [out_location])
+             minitree_paths=[out_location])
+
 
 def verify():
     """Verify the file
@@ -34,27 +29,19 @@ def verify():
 
 
 def _process_hax(name, in_location, host, pax_version,
-             out_location, detector='tpc'):
+                 out_location, detector='tpc'):
     """Called by another command.
     """
     print('Welcome to cax-process-hax')
 
-    # Grab the Run DB so we can query it
-    collection = config.mongo_collection()
-
-    if detector == 'muon_veto':
-        output_fullname = out_location + '/' + name + '_MV'
-    elif detector == 'tpc':
-        output_fullname = out_location + '/' + name
-
     os.makedirs(out_location, exist_ok=True)
 
     try:
-        print ('creating hax minitrees for run', name, pax_version, in_location, out_location)
+        print('creating hax minitrees for run', name, pax_version, in_location, out_location)
         init_hax(in_location, pax_version, out_location)   # may initialize once only
         hax.minitrees.load_single_dataset(name, ['Corrections', 'Basics', 'Fundamentals',
-                                  'DoubleScatter', 'LargestPeakProperties',
-                                  'TotalProperties',  'Extended', 'Proximity'])
+                                                 'DoubleScatter', 'LargestPeakProperties',
+                                                 'TotalProperties',  'Extended', 'Proximity'])
 
     except Exception as exception:
         raise
@@ -82,8 +69,8 @@ class ProcessBatchQueueHax(Task):
             return
 
         in_location = os.path.dirname(have_processed['location'])
-        out_location = config.get_minitrees_dir(thishost,pax_version)
-            
+        out_location = config.get_minitrees_dir(thishost, pax_version)
+
         queue_list = qsub.get_queue(thishost)
 
         # Should check version here too
@@ -93,14 +80,12 @@ class ProcessBatchQueueHax(Task):
             return
 
         self.log.info("Processing %s (%s) with hax_%s, output to %s",
-                      self.run_doc['name'], pax_version, hax_version, 
+                      self.run_doc['name'], pax_version, hax_version,
                       out_location)
-
 
         _process_hax(self.run_doc['name'], in_location, thishost,
                      pax_version, out_location,
                      self.run_doc['detector'])
-
 
     def local_data_finder(self, thishost, pax_version):
         have_processed = False
@@ -116,7 +101,7 @@ class ProcessBatchQueueHax(Task):
             if datum['host'] != thishost:
                 continue
 
-            # Check for raw data 
+            # Check for raw data
             if datum['type'] == 'raw' and datum['status'] == 'transferred':
                 have_raw = datum
 
@@ -124,7 +109,7 @@ class ProcessBatchQueueHax(Task):
             if datum['type'] == 'processed' and datum['status'] == 'transferred':
                 if pax_version == datum['pax_version']:
                     have_processed = datum
-                    
+
         return have_processed, have_raw
 
 


### PR DESCRIPTION
Fixes issue reported by @ftoschi and @coderdj about wrong pax file used in hax minitree generation when older pax version was expected.

Main change is including ```pax_version_policy``` in ```hax.init```.