### PR TITLE
Make all cax jobs run in same directory

### DIFF
--- a/cax/config.py
+++ b/cax/config.py
@@ -254,16 +254,16 @@ def processing_script(args={}):
 export PATH={anaconda}:$PATH
 export JOB_WORKING_DIR={base}/{use}/{number}_{pax_version}
 mkdir -p ${{JOB_WORKING_DIR}}
-cd ${{JOB_WORKING_DIR}}
+cd ${{JOB_WORKING_DIR}}/..
 
-ln -sf {base}/{use}/pax_* .
+#ln -sf {base}/{use}/pax_* .
 
 source activate pax_{pax_version}
 
 HOSTNAME={host}
-{command}
+{command} --log-file ${{JOB_WORKING_DIR}}/cax.log
 
-rm -f pax_event_class*
+rm -f ${{JOB_WORKING_DIR}}/pax_event_class*
 
 {stats}
 """.format(**args)


### PR DESCRIPTION
to prevent ROOT library recompilation (fixes #118), while keeping logs in their respective dirs.

This does not actually solve the underlying issue described in #118, but should be fine as long as running from the same directory is OK (which should be find since I kept the log writing into separate directories).

Note: ```rm -f ${{JOB_WORKING_DIR}}/pax_event_class*``` is temporarily kept to clean up directories after jobs were prematurely killed.