### PR TITLE
Fix for inconsistent creation_time formats in RunsDB (#40)

### DIFF
--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -42,7 +42,7 @@ class RetryStalledTransfer(checksum.CompareChecksums):
         time_made = data_doc['creation_time']
 
         # Some RunsDB entries are different format for some reason (#40)
-        if type(time_made) is list:
+        if isinstance(time_made, list):
             # Assume only one list entry that contains the time
             time_made = time_made[0]
 

--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -40,6 +40,12 @@ class RetryStalledTransfer(checksum.CompareChecksums):
             time_modified = 0
         time_modified = datetime.datetime.fromtimestamp(time_modified)
         time_made = data_doc['creation_time']
+
+        # Some RunsDB entries are different format for some reason (#40)
+        if type(time_made) is list:
+            # Assume only one list entry that contains the time
+            time_made = time_made[0]
+
         difference = datetime.datetime.utcnow() - max(time_modified,
                                                       time_made)
 


### PR DESCRIPTION
Fixes #40 

Though should try to fix ```creation_time``` format in RunsDB retroactively.

Currently manually installed in ```pax_v6.8.0``` environment as a temporary workaround.