### PR TITLE
tigger events_build error still present. Fixed with a check

### DIFF
--- a/cax/tasks/filesystem.py
+++ b/cax/tasks/filesystem.py
@@ -190,6 +190,10 @@ class AddSize(Task):
         trigger = self.run_doc['trigger']
         reader = self.run_doc['reader']
 
+        if 'events_built' not in trigger:
+	   self.log.debug("Events not build in Name: %s " %(self.run_doc['name']) )
+	   return
+
         evn_per_zip = 0
         
         if 'trigger_config_override' not in reader['ini']:


### PR DESCRIPTION
I had to make a check for the trigger field `events_build` because still provide an error.

I found a problem on datamanager there are several very old data (161130_1114 for example) where my user don't have permission to read the data. 
@XeBoris can you check the permission on the rucio/tsm side??

Anyway the code seems to work fine in all the other cases.