### PR TITLE
Reinstate iterative mode

### DIFF
--- a/cax/main.py
+++ b/cax/main.py
@@ -263,17 +263,17 @@ def massive():
     while True:  # yeah yeah
         query = {}
 
-        #t1 = datetime.datetime.utcnow()
-        # if t1 - t0 < dt:
-        #    logging.info("Iterative mode")
+        t1 = datetime.datetime.utcnow()
+        if t1 - t0 < dt:
+            logging.info("Iterative mode")
 
-        #    # See if there is something to do
-        #    query['start'] = {'$gt' : t0}
+            # See if there is something to do
+            query['start'] = {'$gt' : t0}
 
-        #    logging.info(query)
-        # else:
-        #    logging.info("Full mode")
-        #    t0 = t1
+            logging.info(query)
+        else:
+            logging.info("Full mode")
+            t0 = t1
 
         if args.run:
             query['number'] = args.run


### PR DESCRIPTION
Re-enable "iterative" mode, which only loops over most recent runs after one full iteration, to reduce the total number of jobs submitted over time.

During massive reprocessings, then ```massive-cax``` should be restarted manually to catch any stragglers.

Better, but longer-term solution of Implementing a check prior to submitting any job still to be considered.