### PR TITLE
Only print pax version for processed data

### DIFF
--- a/cax/tasks/clear.py
+++ b/cax/tasks/clear.py
@@ -95,8 +95,11 @@ class RetryBadChecksumTransfer(checksum.CompareChecksums):
             return
 
         if data_doc['checksum'] != comparison:
-            self.give_error("Bad checksum %d, %s, %s, %s" % (self.run_doc['number'], data_doc['host'], \
-                            data_doc['type'], data_doc['pax_version']))
+            self.give_error("Bad checksum %d, %s, %s" % (self.run_doc['number'], data_doc['host'], \
+                            data_doc['type']))
+
+            if data_doc['type'] == 'processed':
+                self.give_error("Bad checksum %s" % data_doc['pax_version'])
 
             if self.check(data_doc['type'], warn=False) > 1:
                 self.purge(data_doc)


### PR DESCRIPTION
Should fix this error that appeared while running cax daemon in local mode:
```
File "/project/lgrandi/anaconda3/envs/pax_v6.8.0/lib/python3.4/site-packages/cax-5.2.1-py3.4.egg/cax/tasks/clear.py", line 99, in each_location
    data_doc['type'], data_doc['pax_version']))
KeyError: 'pax_version'
```