### PR TITLE
Catch missing information from dsmc (tape uploader)

### DIFF
--- a/cax/tasks/tsm_mover.py
+++ b/cax/tasks/tsm_mover.py
@@ -184,6 +184,7 @@ class TSMclient(Task):
 
         tno_dict = {
             "tno_inspected": -1,
+            "tno_backedup": -1,
             "tno_updated": -1,
             "tno_rebound": -1,
             "tno_deleted": -1,


### PR DESCRIPTION
Dear all,

Just a quick fix to regarding a missing key in a dictionary. Furthermore I implemented two further tests which check the upload and download dictionaries for keys/information which are written to the log files. These checks avoid undefined transfer status and put in an error in the runDB for tape uploads in case an important information is missing. It is expected to have missing information due to failures in upload and download from tape.
