### PR TITLE
Remove electron lifetime from corrections and task list

### DIFF
--- a/cax/main.py
+++ b/cax/main.py
@@ -99,8 +99,6 @@ def main():
             config.set_json(args.config_file)
 
     tasks = [
-        # Add electron lifetime to run, which is just a function of calendar time
-        corrections.AddElectronLifetime(),
         # Adds gains to a run, where this is computed using slow control information
         corrections.AddGains(),
         # Adds drift velocity to the run, also computed from slow control info

--- a/cax/tasks/corrections.py
+++ b/cax/tasks/corrections.py
@@ -88,20 +88,6 @@ class CorrectionBase(Task):
         return self.function.evalf(subs=kwargs)
 
 
-class AddElectronLifetime(CorrectionBase):
-    """Insert the electron lifetime appropriate to each run"""
-    key = 'processor.DEFAULT.electron_lifetime_liquid'
-    collection_name = 'purity'
-
-    def evaluate(self):
-        t = sympy.symbols('t', integer=True)
-        lifetime = self.function.evalf(subs={t: self.run_doc['start'].replace(tzinfo=pytz.utc).timestamp()})
-        lifetime = float(lifetime)      # Convert away from Sympy type.
-        self.log.info("Run %d: calculated lifetime of %d us" % (self.run_doc['number'], lifetime))
-
-        return lifetime * units.us
-
-
 class AddDriftVelocity(CorrectionBase):
     key = 'processor.DEFAULT.drift_velocity_liquid'
     collection_name = 'drift_velocity'


### PR DESCRIPTION
I think this is all that's needed, right? Removed the function from corrections.py and took the task out of the task list.

For posterity we're removing this correction because it is now done in hax and the outdated format expected by cax was causing problems in processing when it defaulted to zero.