### PR TITLE
Use correct username when checking queue count

### DIFF
--- a/cax/config.py
+++ b/cax/config.py
@@ -15,6 +15,7 @@ import pymongo
 CAX_CONFIGURE = ''
 DATABASE_LOG = True
 HOST = os.environ.get("HOSTNAME") if os.environ.get("HOSTNAME") else socket.gethostname().split('.')[0]
+USER = os.environ.get("USER")
 DATA_USER_PDC = 'bobau'
 DATA_GROUP_PDC = 'xenon-users'
 NCPU = 1
@@ -49,6 +50,11 @@ def mongo_password():
                                'Then rerun this command.')
     return mongo_pwd
 
+def get_user():
+    """Get username of user running this
+    """
+    global USER
+    return USER
 
 def get_hostname():
     """Get hostname of the machine we're running on.

--- a/cax/qsub.py
+++ b/cax/qsub.py
@@ -86,6 +86,7 @@ def delete_script(fileobj):
 
 
 def get_number_in_queue(host=config.get_hostname(), partition=''):
+    print (len(get_queue(host, partition)), host, partition)
     return len(get_queue(host, partition))
 
 
@@ -94,7 +95,7 @@ def get_queue(host=config.get_hostname(), partition=''):
 
     if host == "midway-login1":
         args = {'partition': 'sandyb',
-                'user' : 'mklinton'}
+                'user' : config.get_user()}
     elif host == 'tegner-login-1':
         args = {'partition': 'main',
                 'user' : 'bobau'}

--- a/cax/qsub.py
+++ b/cax/qsub.py
@@ -86,7 +86,7 @@ def delete_script(fileobj):
 
 
 def get_number_in_queue(host=config.get_hostname(), partition=''):
-    print (len(get_queue(host, partition)), host, partition)
+    # print (len(get_queue(host, partition)), host, partition)
     return len(get_queue(host, partition))
 
 


### PR DESCRIPTION
Automatically get username when checking queue count for pausing ```massive-cax``` (wasn't working after switching users since username was hardcoded).