### PR TITLE
Retry corrupt minitree generation

### DIFF
--- a/cax/tasks/process_hax.py
+++ b/cax/tasks/process_hax.py
@@ -57,6 +57,7 @@ def _process_hax(name, in_location, host, pax_version,
 
             except Exception as exception:
                 os.remove("%s/%s_%s.root" % (out_location, name, treemaker))
+                print ("Deleting %s/%s_%s.root" % (out_location, name, treemaker))
                 nRetries -= 1
                 if nRetries == 0:
                     raise

--- a/cax/tasks/process_hax.py
+++ b/cax/tasks/process_hax.py
@@ -36,16 +36,30 @@ def _process_hax(name, in_location, host, pax_version,
 
     os.makedirs(out_location, exist_ok=True)
 
-    try:
-        print('creating hax minitrees for run', name, pax_version, in_location, out_location)
-        init_hax(in_location, pax_version, out_location)   # may initialize once only
-        hax.minitrees.load_single_dataset(name, ['Corrections', 'Basics', 'Fundamentals',
-                                                 'CorrectedDoubleS1Scatter', 'LargestPeakProperties',
-                                                 'TotalProperties',  'Extended', 'Proximity','LoneSignalsPreS1', 
-                                                 'LoneSignals', 'FlashIdentification'])
+    init_hax(in_location, pax_version, out_location)   # may initialize once only
 
-    except Exception as exception:
-        raise
+    print('creating hax minitrees for run', name, pax_version, in_location, out_location)
+
+    TREEMAKERS = ['Corrections', 'Basics', 'Fundamentals',
+                  'CorrectedDoubleS1Scatter', 'LargestPeakProperties',
+                  'TotalProperties',  'Extended', 'Proximity','LoneSignalsPreS1',
+                  'LoneSignals', 'FlashIdentification']
+
+    for treemaker in TREEMAKERS:
+
+        nRetries = 5
+
+        while nRetries > 0:
+            try:
+                print ('Creating minitree', treemaker)
+                hax.minitrees.load_single_dataset(name, treemaker)
+                nRetries = 0
+
+            except Exception as exception:
+                os.remove("%s/%s_%s.root" % (out_location, name, treemaker))
+                nRetries -= 1
+                if nRetries == 0:
+                    raise
 
 
 class ProcessBatchQueueHax(Task):

--- a/cax/tasks/process_hax.py
+++ b/cax/tasks/process_hax.py
@@ -42,7 +42,7 @@ def _process_hax(name, in_location, host, pax_version,
 
     TREEMAKERS = ['Corrections', 'Basics', 'Fundamentals',
                   'CorrectedDoubleS1Scatter', 'LargestPeakProperties',
-                  'TotalProperties',  'Extended', 'Proximity','LoneSignalsPreS1',
+                  'TotalProperties', 'Extended', 'Proximity', 'LoneSignalsPreS1',
                   'LoneSignals', 'FlashIdentification']
 
     for treemaker in TREEMAKERS:
@@ -51,13 +51,13 @@ def _process_hax(name, in_location, host, pax_version,
 
         while nRetries > 0:
             try:
-                print ('Creating minitree', treemaker)
+                print('Creating minitree', treemaker)
                 hax.minitrees.load_single_dataset(name, treemaker)
                 nRetries = 0
 
             except Exception as exception:
                 os.remove("%s/%s_%s.root" % (out_location, name, treemaker))
-                print ("Deleting %s/%s_%s.root" % (out_location, name, treemaker))
+                print("Deleting %s/%s_%s.root" % (out_location, name, treemaker))
                 nRetries -= 1
                 if nRetries == 0:
                     raise


### PR DESCRIPTION
If a minitree is corrupt, hax just crashes when trying to load it and doesn't regenerate. This PR allows cax to detect that crash, delete the corrupt minitree and retry.

Note: this will retry on any exception, not just corrupt file error.