### PR TITLE
Disable corrections that moved to hax

### DIFF
--- a/cax/main.py
+++ b/cax/main.py
@@ -103,9 +103,9 @@ def main():
         corrections.AddGains(),
         # Adds drift velocity to the run, also computed from slow control info
         corrections.AddDriftVelocity(),
-        corrections.SetS2xyMap(),
-        corrections.SetLightCollectionEfficiency(),
-        corrections.SetFieldDistortion(),
+        # corrections.SetS2xyMap(),
+        # corrections.SetLightCollectionEfficiency(),
+        # corrections.SetFieldDistortion(),
         corrections.SetNeuralNetwork(),
         # corrections.AddSlowControlInformation(),
         data_mover.CopyPush(),  # Upload data through e.g. scp or gridftp to this location where cax running


### PR DESCRIPTION
This disables cax tasks that added run doc overrides for corrections that have moved to hax. These are now so far out of date the correction map files they reference no longer exist, breaking various things (shifter notebooks, waveform inspection code, etc). 

After merging this, we'd still have to
  * Update the cax(es) that runs the correction tasks (I don't know where); unless this happens automatically
  * Scrub the references to the outdated correction maps from the run docs (I could do this).

The alternative to this is to update the corrections db with all the new corrections in hax.ini. I doubt we want to to do this and maintain two separate systems. 